### PR TITLE
Add license and terms section to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ We have implemented several safeguards to protect your data, including limited r
 
 For full details, please review our [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms) and [Privacy Policy](https://www.anthropic.com/legal/privacy).
 
+## License and terms
+
+Use of this SDK is governed by Anthropic's [Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms), including when you use it to power products and services that you make available to your own customers and end users, except to the extent a specific component or dependency is covered by a different license as indicated in that component's LICENSE file.
+


### PR DESCRIPTION
Add "License and terms" section to README clarifying that use of the SDK is governed by Anthropic's Commercial Terms of Service