### PR TITLE
chore: Remove reverted listSessions entry from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.2.27
 
-- Added `listSessions` function to discover resumable sessions by project, repo, or globally
 - Added optional `annotations` support to the `tool()` helper function for specifying MCP tool hints (readOnlyHint, destructiveHint, openWorldHint, idempotentHint)
 - Fixed `mcpServerStatus()` to include tools from SDK and dynamically-added MCP servers
 - Updated to parity with Claude Code v2.1.27


### PR DESCRIPTION
The listSessions feature entry was reverted but its changelog entry remained. This removes the stale changelog line from the 0.2.27 section.