### PR TITLE
Use wrapper script for label operations in issue triage

### DIFF
--- a/.claude/commands/label-issue.md
+++ b/.claude/commands/label-issue.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh label list:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh search:*)
+allowed-tools: Bash(gh label list:*),Bash(gh issue view:*),Bash(./scripts/edit-issue-labels.sh:*),Bash(gh search issues:*)
 description: Apply labels to GitHub issues
 ---
 
@@ -23,8 +23,8 @@ TASK OVERVIEW:
    - You have access to these Bash commands:
      - Bash(gh label list:\*) - to get available labels
      - Bash(gh issue view:\*) - to view issue details
-     - Bash(gh issue edit:\*) - to apply labels to the issue
-     - Bash(gh search:\*) - to search for similar issues
+     - Bash(./scripts/edit-issue-labels.sh:\*) - to apply labels to the issue
+     - Bash(gh search issues:\*) - to search for similar issues
 
 3. Analyze the issue content, considering:
 
@@ -44,7 +44,7 @@ TASK OVERVIEW:
    - If you find similar issues using gh search, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
 
 5. Apply the selected labels:
-   - Use `gh issue edit` to apply your selected labels
+   - Use `./scripts/edit-issue-labels.sh --issue NUMBER --add-label LABEL1 --add-label LABEL2` to apply your selected labels
    - DO NOT post any comments explaining your decision
    - DO NOT communicate directly with users
    - If no labels are clearly applicable, do not apply any labels
@@ -54,7 +54,7 @@ IMPORTANT GUIDELINES:
 - Be thorough in your analysis
 - Only select labels from the provided list above
 - DO NOT post any comments to the issue
-- Your ONLY action should be to apply labels using gh issue edit
+- Your ONLY action should be to apply labels using ./scripts/edit-issue-labels.sh
 - It's okay to not add any labels if none are clearly applicable
 
 ---

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-action@main
         with:
-          prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER${{ github.event.issue.number }}"
+          prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_non_write_users: "*" # Required for issue triage workflow, if users without repo write access create issues
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Edits labels on a GitHub issue.
+# Usage: ./scripts/edit-issue-labels.sh --issue 123 --add-label bug --add-label needs-triage --remove-label untriaged
+#
+
+set -euo pipefail
+
+ISSUE=""
+ADD_LABELS=()
+REMOVE_LABELS=()
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --issue)
+      ISSUE="$2"
+      shift 2
+      ;;
+    --add-label)
+      ADD_LABELS+=("$2")
+      shift 2
+      ;;
+    --remove-label)
+      REMOVE_LABELS+=("$2")
+      shift 2
+      ;;
+    *)
+      exit 1
+      ;;
+  esac
+done
+
+# Validate issue number
+if [[ -z "$ISSUE" ]]; then
+  exit 1
+fi
+
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  exit 1
+fi
+
+if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
+  exit 1
+fi
+
+# Fetch valid labels from the repo
+VALID_LABELS=$(gh label list --limit 500 --json name --jq '.[].name')
+
+# Filter to only labels that exist in the repo
+FILTERED_ADD=()
+for label in "${ADD_LABELS[@]}"; do
+  if echo "$VALID_LABELS" | grep -qxF "$label"; then
+    FILTERED_ADD+=("$label")
+  fi
+done
+
+FILTERED_REMOVE=()
+for label in "${REMOVE_LABELS[@]}"; do
+  if echo "$VALID_LABELS" | grep -qxF "$label"; then
+    FILTERED_REMOVE+=("$label")
+  fi
+done
+
+if [[ ${#FILTERED_ADD[@]} -eq 0 && ${#FILTERED_REMOVE[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Build gh command arguments
+GH_ARGS=("issue" "edit" "$ISSUE")
+
+for label in "${FILTERED_ADD[@]}"; do
+  GH_ARGS+=("--add-label" "$label")
+done
+
+for label in "${FILTERED_REMOVE[@]}"; do
+  GH_ARGS+=("--remove-label" "$label")
+done
+
+gh "${GH_ARGS[@]}"
+
+if [[ ${#FILTERED_ADD[@]} -gt 0 ]]; then
+  echo "Added: ${FILTERED_ADD[*]}"
+fi
+if [[ ${#FILTERED_REMOVE[@]} -gt 0 ]]; then
+  echo "Removed: ${FILTERED_REMOVE[*]}"
+fi


### PR DESCRIPTION
Updates /label-issue command to use a dedicated edit-issue-labels.sh script for label operations instead of raw gh issue edit. The script validates labels against the repo's existing labels before applying them. Also tightens gh search permission to gh search issues.