### PR TITLE
Add gh.sh wrapper for gh CLI commands in issue triage workflows

### DIFF
--- a/.claude/commands/label-issue.md
+++ b/.claude/commands/label-issue.md
@@ -1,5 +1,5 @@
 ---
-allowed-tools: Bash(gh label list:*),Bash(gh issue view:*),Bash(./scripts/edit-issue-labels.sh:*),Bash(gh search issues:*)
+allowed-tools: Bash(./scripts/gh.sh:*),Bash(./scripts/edit-issue-labels.sh:*)
 description: Apply labels to GitHub issues
 ---
 
@@ -14,17 +14,18 @@ Issue Information:
 
 TASK OVERVIEW:
 
-1. First, fetch the list of labels available in this repository by running: `gh label list`. Run exactly this command with nothing else.
+1. First, fetch the list of labels available in this repository by running: `./scripts/gh.sh label list`. Run exactly this command with nothing else.
 
-2. Next, use gh commands to get context about the issue:
+2. Next, use gh wrapper commands to get context about the issue:
 
-   - Use `gh issue view ${{ github.event.issue.number }}` to retrieve the current issue's details
-   - Use `gh search issues` to find similar issues that might provide context for proper categorization
-   - You have access to these Bash commands:
-     - Bash(gh label list:\*) - to get available labels
-     - Bash(gh issue view:\*) - to view issue details
-     - Bash(./scripts/edit-issue-labels.sh:\*) - to apply labels to the issue
-     - Bash(gh search issues:\*) - to search for similar issues
+   - Use `./scripts/gh.sh issue view ${{ github.event.issue.number }}` to retrieve the current issue's details
+   - Use `./scripts/gh.sh search issues` to find similar issues that might provide context for proper categorization
+   - `./scripts/gh.sh` is a wrapper for `gh` CLI. Example commands:
+     - `./scripts/gh.sh label list` — fetch all available labels
+     - `./scripts/gh.sh issue view 123` — view issue details
+     - `./scripts/gh.sh issue view 123 --comments` — view with comments
+     - `./scripts/gh.sh search issues "query" --limit 10` — search for issues
+   - `./scripts/edit-issue-labels.sh` — apply labels to the issue
 
 3. Analyze the issue content, considering:
 
@@ -39,9 +40,9 @@ TASK OVERVIEW:
 
    - Choose labels that accurately reflect the issue's nature
    - Be specific but comprehensive
-   - IMPORTANT: Add a priority label (P1, P2, or P3) based on the label descriptions from gh label list
+   - IMPORTANT: Add a priority label (P1, P2, or P3) based on the label descriptions from ./scripts/gh.sh label list
    - Consider platform labels (android, ios) if applicable
-   - If you find similar issues using gh search, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
+   - If you find similar issues using ./scripts/gh.sh search, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
 
 5. Apply the selected labels:
    - Use `./scripts/edit-issue-labels.sh --issue NUMBER --add-label LABEL1 --add-label LABEL2` to apply your selected labels

--- a/scripts/gh.sh
+++ b/scripts/gh.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Wrapper around gh CLI that only allows specific subcommands and flags.
+# All commands are scoped to the current repository via GH_REPO or GITHUB_REPOSITORY.
+#
+# Usage:
+#   ./scripts/gh.sh issue view 123
+#   ./scripts/gh.sh issue view 123 --comments
+#   ./scripts/gh.sh issue list --state open --limit 20
+#   ./scripts/gh.sh search issues "search query" --limit 10
+#   ./scripts/gh.sh label list --limit 100
+
+ALLOWED_FLAGS=(--comments --state --limit --label)
+FLAGS_WITH_VALUES=(--state --limit --label)
+
+SUB1="${1:-}"
+SUB2="${2:-}"
+CMD="$SUB1 $SUB2"
+case "$CMD" in
+  "issue view"|"issue list"|"search issues"|"label list")
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+
+shift 2
+
+# Separate flags from positional arguments
+POSITIONAL=()
+FLAGS=()
+skip_next=false
+for arg in "$@"; do
+  if [[ "$skip_next" == true ]]; then
+    FLAGS+=("$arg")
+    skip_next=false
+  elif [[ "$arg" == -* ]]; then
+    flag="${arg%%=*}"
+    matched=false
+    for allowed in "${ALLOWED_FLAGS[@]}"; do
+      if [[ "$flag" == "$allowed" ]]; then
+        matched=true
+        break
+      fi
+    done
+    if [[ "$matched" == false ]]; then
+      exit 1
+    fi
+    FLAGS+=("$arg")
+    # If flag expects a value and isn't using = syntax, skip next arg
+    if [[ "$arg" != *=* ]]; then
+      for vflag in "${FLAGS_WITH_VALUES[@]}"; do
+        if [[ "$flag" == "$vflag" ]]; then
+          skip_next=true
+          break
+        fi
+      done
+    fi
+  else
+    POSITIONAL+=("$arg")
+  fi
+done
+
+REPO="${GH_REPO:-${GITHUB_REPOSITORY:-}}"
+
+if [[ "$CMD" == "search issues" ]]; then
+  if [[ -z "$REPO" ]]; then
+    exit 1
+  fi
+  QUERY="${POSITIONAL[0]:-}"
+  QUERY_LOWER=$(echo "$QUERY" | tr '[:upper:]' '[:lower:]')
+  if [[ "$QUERY_LOWER" == *"repo:"* || "$QUERY_LOWER" == *"org:"* || "$QUERY_LOWER" == *"user:"* ]]; then
+    exit 1
+  fi
+  gh "$SUB1" "$SUB2" "$QUERY" --repo "$REPO" "${FLAGS[@]}"
+else
+  # Reject URLs in positional args to prevent cross-repo access
+  for pos in "${POSITIONAL[@]}"; do
+    if [[ "$pos" == http://* || "$pos" == https://* ]]; then
+      exit 1
+    fi
+  done
+  gh "$SUB1" "$SUB2" "${POSITIONAL[@]}" "${FLAGS[@]}"
+fi


### PR DESCRIPTION
Adds a gh.sh wrapper script that provides a controlled interface to the gh CLI, allowing only specific subcommands (issue view, issue list, search issues, label list) and flags (--comments, --state, --limit, --label). Updates the /label-issue command to use the wrapper.