### PR TITLE
Add missing ./sdk-tools export path to package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed `./sdk-tools` subpath not being resolvable since v0.2.69 by adding the missing `exports` entry to `package.json` (#218)
+
 ## 0.2.71
 
 - Updated to parity with Claude Code v2.1.71


### PR DESCRIPTION
## Summary

Fixes #218 — Since v0.2.69, the `exports` field in `package.json` prevents TypeScript from resolving `@anthropic-ai/claude-agent-sdk/sdk-tools` because no `./sdk-tools` entry was added alongside the `.` and `./embed` entries.

This breaks imports like:
```typescript
import type { GlobInput } from "@anthropic-ai/claude-agent-sdk/sdk-tools";
```

## Proposed fix

Add the following entry to the `exports` field in `package.json`:

```json
"./sdk-tools": {
  "types": "./sdk-tools.d.ts"
}
```

Since `sdk-tools.d.ts` is a types-only file (no runtime `.mjs`/`.js` counterpart), only the `types` condition is needed.

The full `exports` field would become:

```json
"exports": {
  ".": {
    "types": "./sdk.d.ts",
    "default": "./sdk.mjs"
  },
  "./embed": {
    "types": "./embed.d.ts",
    "default": "./embed.js"
  },
  "./sdk-tools": {
    "types": "./sdk-tools.d.ts"
  }
}
```

Since `package.json` is maintained in the internal build, this PR adds the corresponding CHANGELOG entry and documents the fix for the team to apply.