### PR TITLE
fix: escape issue title in Slack notification to prevent JSON breakage

### DIFF
--- a/.github/workflows/slack-issue-notification.yml
+++ b/.github/workflows/slack-issue-notification.yml
@@ -8,29 +8,47 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
+      - name: Build Slack payload
+        id: payload
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          REPO_NAME: ${{ github.repository }}
+        run: |
+          PAYLOAD=$(jq -nc \
+            --arg channel "C09HY5E0K60" \
+            --arg repo "$REPO_NAME" \
+            --arg url "$ISSUE_URL" \
+            --arg num "$ISSUE_NUMBER" \
+            --arg title "$ISSUE_TITLE" \
+            --arg author "$ISSUE_AUTHOR" \
+            '{
+              channel: $channel,
+              text: "New issue opened in \($repo)",
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*New Issue:* <\($url)|#\($num) \($title)>"
+                  }
+                },
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: "*Author:* \($author)"
+                  }
+                }
+              ]
+            }')
+          echo "json=$PAYLOAD" >> "$GITHUB_OUTPUT"
+
       - name: Post to Slack
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # 2.1.1
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
-          payload: |
-            {
-              "channel": "C09HY5E0K60",
-              "text": "New issue opened in ${{ github.repository }}",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*New Issue:* <${{ github.event.issue.html_url }}|#${{ github.event.issue.number }} ${{ github.event.issue.title }}>"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Author:* ${{ github.event.issue.user.login }}"
-                  }
-                }
-              ]
-            }
+          payload: ${{ steps.payload.outputs.json }}


### PR DESCRIPTION
## Summary

- Issue titles containing `"`, `\`, newlines, or other JSON-special characters break the `slack-issue-notification.yml` payload, causing Slack notifications to silently fail
- Replaces inline `${{ }}` expression interpolation with a `jq`-based approach that properly JSON-escapes all user-supplied values (`issue.title`, `issue.user.login`, etc.) via `--arg` before embedding them in the payload
- Preserves the same Slack message format, channel, and pinned action version

## Problem

The current workflow interpolates `${{ github.event.issue.title }}` directly into a JSON string literal:

```json
"text": "*New Issue:* <url|#123 ${{ github.event.issue.title }}>"
```

If someone opens an issue titled `Bug: "undefined" is not a function`, the expanded payload becomes:

```json
"text": "*New Issue:* <url|#123 Bug: "undefined" is not a function>"
```

This is invalid JSON. The `slackapi/slack-github-action` action fails to parse it and the notification is never sent.

## Fix

Event data is passed through environment variables into a `run` step that uses `jq --arg` to build the payload. `jq` handles all JSON escaping automatically, so any title — including those with quotes, backslashes, angle brackets, or newlines — produces valid JSON.

## Test plan

- [ ] Open a test issue with a normal title and verify the Slack notification arrives
- [ ] Open a test issue with special characters in the title (e.g. `Test "quotes" and \backslash`) and verify the notification still arrives with the correct title

## AI Disclosure

This PR was authored by Claude Opus 4.6 (Anthropic), an AI agent operated by Maxwell Calkin ([@MaxwellCalkin](https://github.com/MaxwellCalkin)).