### PR TITLE
fix(ProcessTransport): prevent ERR_STREAM_WRITE_AFTER_END race after endInput()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,57 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        run: npm run typecheck
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run tests with coverage
+        if: matrix.node-version == '20.x'
+        run: npm run test:coverage
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check TypeScript types
+        run: npm run typecheck

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Coverage reports
+coverage/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+
+# Test
+.vitest/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2568 @@
+{
+  "name": "claude-agent-sdk-typescript-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-agent-sdk-typescript-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.72",
+        "@types/node": "^20.10.0",
+        "@vitest/coverage-v8": "^2.1.0",
+        "typescript": "^5.3.0",
+        "vitest": "^2.1.0",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.72",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.72.tgz",
+      "integrity": "sha512-GR3QaLRCoWO5DkRknaaCH6zzmUNZ3E6VckEKNE7EO5R7qDBexQe9tDKag257pji2NenTrnBDMxznoZrhNCRTzA==",
+      "dev": true,
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
+      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.5"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
+      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.53.3.tgz",
+      "integrity": "sha512-mRSi+4cBjrRLoaal2PnqH82Wqyb+d3HsPUN/W+WslCXsZsyHa9ZeQQX/pQsZaVIWDkPcpV6jJ+3KLbTbgnwv8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.53.3.tgz",
+      "integrity": "sha512-CbDGaMpdE9sh7sCmTrTUyllhrg65t6SwhjlMJsLr+J8YjFuPmCEjbBSx4Z/e4SmDyH3aB5hGaJUP2ltV/vcs4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.53.3.tgz",
+      "integrity": "sha512-Nr7SlQeqIBpOV6BHHGZgYBuSdanCXuw09hon14MGOLGmXAFYjx1wNvquVPmpZnl0tLjg25dEdr4IQ6GgyToCUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.53.3.tgz",
+      "integrity": "sha512-DZ8N4CSNfl965CmPktJ8oBnfYr3F8dTTNBQkRlffnUarJ2ohudQD17sZBa097J8xhQ26AwhHJ5mvUyQW8ddTsQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.53.3.tgz",
+      "integrity": "sha512-yMTrCrK92aGyi7GuDNtGn2sNW+Gdb4vErx4t3Gv/Tr+1zRb8ax4z8GWVRfr3Jw8zJWvpGHNpss3vVlbF58DZ4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.53.3.tgz",
+      "integrity": "sha512-lMfF8X7QhdQzseM6XaX0vbno2m3hlyZFhwcndRMw8fbAGUGL3WFMBdK0hbUBIUYcEcMhVLr1SIamDeuLBnXS+Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.53.3.tgz",
+      "integrity": "sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.53.3.tgz",
+      "integrity": "sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.53.3.tgz",
+      "integrity": "sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.53.3.tgz",
+      "integrity": "sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.53.3.tgz",
+      "integrity": "sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.53.3.tgz",
+      "integrity": "sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.53.3.tgz",
+      "integrity": "sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.53.3.tgz",
+      "integrity": "sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.53.3.tgz",
+      "integrity": "sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.53.3.tgz",
+      "integrity": "sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.53.3.tgz",
+      "integrity": "sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.53.3.tgz",
+      "integrity": "sha512-GOFuKpsxR/whszbF/bzydebLiXIHSgsEUp6M0JI8dWvi+fFa1TD6YQa4aSZHtpmh2/uAlj/Dy+nmby3TJ3pkTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.53.3.tgz",
+      "integrity": "sha512-iah+THLcBJdpfZ1TstDFbKNznlzoxa8fmnFYK4V67HvmuNYkVdAywJSoteUszvBQ9/HqN2+9AZghbajMsFT+oA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.53.3.tgz",
+      "integrity": "sha512-J9QDiOIZlZLdcot5NXEepDkstocktoVjkaKUtqzgzpt2yWjGlbYiKyp05rWwk4nypbYUNoFAztEgixoLaSETkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.53.3.tgz",
+      "integrity": "sha512-UhTd8u31dXadv0MopwGgNOBpUVROFKWVQgAg5N1ESyCz8AuBcMqm4AuTjrwgQKGDfoFuz02EuMRHQIw/frmYKQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.26.tgz",
+      "integrity": "sha512-0l6cjgF0XnihUpndDhk+nyD3exio3iKaYROSgvh/qSevPXax3L8p5DBRFjbvalnwatGgHEQn2R88y2fA3g4irg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.53.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.53.3.tgz",
+      "integrity": "sha512-w8GmOxZfBmKknvdXU1sdM9NHcoQejwF/4mNgj2JuEEdRaHwwF12K7e9eXn1nLZ07ad+du76mkVsyeb2rKGllsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.53.3",
+        "@rollup/rollup-android-arm64": "4.53.3",
+        "@rollup/rollup-darwin-arm64": "4.53.3",
+        "@rollup/rollup-darwin-x64": "4.53.3",
+        "@rollup/rollup-freebsd-arm64": "4.53.3",
+        "@rollup/rollup-freebsd-x64": "4.53.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.53.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.53.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.53.3",
+        "@rollup/rollup-linux-arm64-musl": "4.53.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.53.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.53.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.53.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-gnu": "4.53.3",
+        "@rollup/rollup-linux-x64-musl": "4.53.3",
+        "@rollup/rollup-openharmony-arm64": "4.53.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.53.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.53.3",
+        "@rollup/rollup-win32-x64-gnu": "4.53.3",
+        "@rollup/rollup-win32-x64-msvc": "4.53.3",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "claude-agent-sdk-typescript-tests",
+  "version": "1.0.0",
+  "description": "Test suite for @anthropic-ai/claude-agent-sdk",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.72",
+    "@types/node": "^20.10.0",
+    "@vitest/coverage-v8": "^2.1.0",
+    "typescript": "^5.3.0",
+    "vitest": "^2.1.0",
+    "zod": "^3.24.1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/tests/exports.test.ts
+++ b/tests/exports.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests to verify that all expected exports from the SDK are available
+ * and have the correct types.
+ */
+import { describe, it, expect } from 'vitest';
+import * as SDK from '@anthropic-ai/claude-agent-sdk';
+
+describe('SDK Exports', () => {
+  describe('Core Functions', () => {
+    it('should export query function', () => {
+      expect(SDK.query).toBeDefined();
+      expect(typeof SDK.query).toBe('function');
+    });
+
+    it('should export tool function', () => {
+      expect(SDK.tool).toBeDefined();
+      expect(typeof SDK.tool).toBe('function');
+    });
+
+    it('should export createSdkMcpServer function', () => {
+      expect(SDK.createSdkMcpServer).toBeDefined();
+      expect(typeof SDK.createSdkMcpServer).toBe('function');
+    });
+  });
+
+  describe('V2 Session API', () => {
+    it('should export unstable_v2_createSession', () => {
+      expect(SDK.unstable_v2_createSession).toBeDefined();
+      expect(typeof SDK.unstable_v2_createSession).toBe('function');
+    });
+
+    it('should export unstable_v2_resumeSession', () => {
+      expect(SDK.unstable_v2_resumeSession).toBeDefined();
+      expect(typeof SDK.unstable_v2_resumeSession).toBe('function');
+    });
+
+    it('should export unstable_v2_prompt', () => {
+      expect(SDK.unstable_v2_prompt).toBeDefined();
+      expect(typeof SDK.unstable_v2_prompt).toBe('function');
+    });
+  });
+
+  describe('Constants', () => {
+    it('should export HOOK_EVENTS array', () => {
+      expect(SDK.HOOK_EVENTS).toBeDefined();
+      expect(Array.isArray(SDK.HOOK_EVENTS)).toBe(true);
+      expect(SDK.HOOK_EVENTS.length).toBeGreaterThan(0);
+    });
+
+    it('should include expected hook events', () => {
+      const expectedEvents = [
+        'PreToolUse',
+        'PostToolUse',
+        'PostToolUseFailure',
+        'Notification',
+        'UserPromptSubmit',
+        'SessionStart',
+        'SessionEnd',
+        'Stop',
+        'SubagentStart',
+        'SubagentStop',
+        'PreCompact',
+        'PermissionRequest',
+      ];
+      for (const event of expectedEvents) {
+        expect(SDK.HOOK_EVENTS).toContain(event);
+      }
+    });
+
+    it('should export EXIT_REASONS array', () => {
+      expect(SDK.EXIT_REASONS).toBeDefined();
+      expect(Array.isArray(SDK.EXIT_REASONS)).toBe(true);
+    });
+  });
+
+  describe('Classes', () => {
+    it('should export AbortError class', () => {
+      expect(SDK.AbortError).toBeDefined();
+      expect(typeof SDK.AbortError).toBe('function');
+    });
+
+    it('AbortError should extend Error', () => {
+      const error = new SDK.AbortError('test');
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(SDK.AbortError);
+      expect(error.message).toBe('test');
+    });
+  });
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for hook types and behaviors
+ */
+import { describe, it, expect } from 'vitest';
+import { HOOK_EVENTS } from '@anthropic-ai/claude-agent-sdk';
+import type {
+  HookEvent,
+  HookInput,
+  HookJSONOutput,
+  HookCallback,
+  HookCallbackMatcher,
+  PreToolUseHookInput,
+  PostToolUseHookInput,
+  PostToolUseFailureHookInput,
+  NotificationHookInput,
+  UserPromptSubmitHookInput,
+  SessionStartHookInput,
+  SessionEndHookInput,
+  StopHookInput,
+  SubagentStartHookInput,
+  SubagentStopHookInput,
+  PreCompactHookInput,
+  PermissionRequestHookInput,
+  SyncHookJSONOutput,
+  AsyncHookJSONOutput,
+} from '@anthropic-ai/claude-agent-sdk';
+
+describe('Hooks', () => {
+  describe('HOOK_EVENTS constant', () => {
+    it('should contain all expected events', () => {
+      expect(HOOK_EVENTS).toContain('PreToolUse');
+      expect(HOOK_EVENTS).toContain('PostToolUse');
+      expect(HOOK_EVENTS).toContain('PostToolUseFailure');
+      expect(HOOK_EVENTS).toContain('Notification');
+      expect(HOOK_EVENTS).toContain('UserPromptSubmit');
+      expect(HOOK_EVENTS).toContain('SessionStart');
+      expect(HOOK_EVENTS).toContain('SessionEnd');
+      expect(HOOK_EVENTS).toContain('Stop');
+      expect(HOOK_EVENTS).toContain('SubagentStart');
+      expect(HOOK_EVENTS).toContain('SubagentStop');
+      expect(HOOK_EVENTS).toContain('PreCompact');
+      expect(HOOK_EVENTS).toContain('PermissionRequest');
+    });
+
+    it('should have 12 hook events', () => {
+      expect(HOOK_EVENTS).toHaveLength(12);
+    });
+
+    it('should be readonly', () => {
+      // TypeScript enforces this at compile time
+      // At runtime, we verify the array exists
+      expect(Array.isArray(HOOK_EVENTS)).toBe(true);
+    });
+  });
+
+  describe('Hook Input Types', () => {
+    it('should support PreToolUseHookInput', () => {
+      const input: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        tool_name: 'Bash',
+        tool_input: { command: 'ls -la' },
+        tool_use_id: 'tool-use-123',
+      };
+
+      expect(input.hook_event_name).toBe('PreToolUse');
+      expect(input.tool_name).toBe('Bash');
+      expect(input.tool_input).toEqual({ command: 'ls -la' });
+    });
+
+    it('should support PostToolUseHookInput', () => {
+      const input: PostToolUseHookInput = {
+        hook_event_name: 'PostToolUse',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        tool_name: 'Read',
+        tool_input: { file_path: '/tmp/test.txt' },
+        tool_response: 'File contents here',
+        tool_use_id: 'tool-use-456',
+      };
+
+      expect(input.hook_event_name).toBe('PostToolUse');
+      expect(input.tool_response).toBe('File contents here');
+    });
+
+    it('should support PostToolUseFailureHookInput', () => {
+      const input: PostToolUseFailureHookInput = {
+        hook_event_name: 'PostToolUseFailure',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        tool_name: 'Bash',
+        tool_input: { command: 'invalid-command' },
+        tool_use_id: 'tool-use-789',
+        error: 'Command not found',
+        is_interrupt: false,
+      };
+
+      expect(input.hook_event_name).toBe('PostToolUseFailure');
+      expect(input.error).toBe('Command not found');
+    });
+
+    it('should support NotificationHookInput', () => {
+      const input: NotificationHookInput = {
+        hook_event_name: 'Notification',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        message: 'Task completed',
+        title: 'Success',
+        notification_type: 'info',
+      };
+
+      expect(input.hook_event_name).toBe('Notification');
+      expect(input.message).toBe('Task completed');
+    });
+
+    it('should support UserPromptSubmitHookInput', () => {
+      const input: UserPromptSubmitHookInput = {
+        hook_event_name: 'UserPromptSubmit',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        prompt: 'Help me fix this bug',
+      };
+
+      expect(input.hook_event_name).toBe('UserPromptSubmit');
+      expect(input.prompt).toBe('Help me fix this bug');
+    });
+
+    it('should support SessionStartHookInput', () => {
+      const sources: SessionStartHookInput['source'][] = [
+        'startup',
+        'resume',
+        'clear',
+        'compact',
+      ];
+
+      for (const source of sources) {
+        const input: SessionStartHookInput = {
+          hook_event_name: 'SessionStart',
+          session_id: 'session-123',
+          transcript_path: '/tmp/transcript.json',
+          cwd: '/home/user/project',
+          source,
+        };
+
+        expect(input.hook_event_name).toBe('SessionStart');
+        expect(input.source).toBe(source);
+      }
+    });
+
+    it('should support SessionEndHookInput', () => {
+      const input: SessionEndHookInput = {
+        hook_event_name: 'SessionEnd',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        reason: 'completed',
+      };
+
+      expect(input.hook_event_name).toBe('SessionEnd');
+      expect(input.reason).toBe('completed');
+    });
+
+    it('should support StopHookInput', () => {
+      const input: StopHookInput = {
+        hook_event_name: 'Stop',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        stop_hook_active: true,
+      };
+
+      expect(input.hook_event_name).toBe('Stop');
+      expect(input.stop_hook_active).toBe(true);
+    });
+
+    it('should support SubagentStartHookInput', () => {
+      const input: SubagentStartHookInput = {
+        hook_event_name: 'SubagentStart',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        agent_id: 'agent-456',
+        agent_type: 'code-reviewer',
+      };
+
+      expect(input.hook_event_name).toBe('SubagentStart');
+      expect(input.agent_id).toBe('agent-456');
+      expect(input.agent_type).toBe('code-reviewer');
+    });
+
+    it('should support SubagentStopHookInput', () => {
+      const input: SubagentStopHookInput = {
+        hook_event_name: 'SubagentStop',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        stop_hook_active: false,
+        agent_id: 'agent-456',
+        agent_transcript_path: '/tmp/agent-transcript.json',
+      };
+
+      expect(input.hook_event_name).toBe('SubagentStop');
+      expect(input.agent_transcript_path).toBe('/tmp/agent-transcript.json');
+    });
+
+    it('should support PreCompactHookInput', () => {
+      const triggers: PreCompactHookInput['trigger'][] = ['manual', 'auto'];
+
+      for (const trigger of triggers) {
+        const input: PreCompactHookInput = {
+          hook_event_name: 'PreCompact',
+          session_id: 'session-123',
+          transcript_path: '/tmp/transcript.json',
+          cwd: '/home/user/project',
+          trigger,
+          custom_instructions: 'Focus on key decisions',
+        };
+
+        expect(input.hook_event_name).toBe('PreCompact');
+        expect(input.trigger).toBe(trigger);
+      }
+    });
+
+    it('should support PermissionRequestHookInput', () => {
+      const input: PermissionRequestHookInput = {
+        hook_event_name: 'PermissionRequest',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        tool_name: 'Edit',
+        tool_input: { file_path: '/etc/passwd' },
+        permission_suggestions: [
+          {
+            type: 'addRules',
+            rules: [{ toolName: 'Edit', ruleContent: '/home/**' }],
+            behavior: 'allow',
+            destination: 'session',
+          },
+        ],
+      };
+
+      expect(input.hook_event_name).toBe('PermissionRequest');
+      expect(input.permission_suggestions).toBeDefined();
+    });
+  });
+
+  describe('Hook Output Types', () => {
+    it('should support SyncHookJSONOutput', () => {
+      const output: SyncHookJSONOutput = {
+        continue: true,
+        suppressOutput: false,
+      };
+
+      expect(output.continue).toBe(true);
+    });
+
+    it('should support SyncHookJSONOutput with decision', () => {
+      const output: SyncHookJSONOutput = {
+        decision: 'approve',
+        reason: 'Safe operation',
+      };
+
+      expect(output.decision).toBe('approve');
+      expect(output.reason).toBe('Safe operation');
+    });
+
+    it('should support SyncHookJSONOutput with hook-specific output', () => {
+      const preToolUseOutput: SyncHookJSONOutput = {
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: 'allow',
+          permissionDecisionReason: 'Approved by admin',
+          updatedInput: { command: 'ls' },
+        },
+      };
+
+      expect(preToolUseOutput.hookSpecificOutput?.hookEventName).toBe(
+        'PreToolUse'
+      );
+
+      const userPromptOutput: SyncHookJSONOutput = {
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'UserPromptSubmit',
+          additionalContext: 'User is testing the SDK',
+        },
+      };
+
+      expect(userPromptOutput.hookSpecificOutput?.hookEventName).toBe(
+        'UserPromptSubmit'
+      );
+    });
+
+    it('should support AsyncHookJSONOutput', () => {
+      const output: AsyncHookJSONOutput = {
+        async: true,
+        asyncTimeout: 30000,
+      };
+
+      expect(output.async).toBe(true);
+      expect(output.asyncTimeout).toBe(30000);
+    });
+
+    it('should support block decision', () => {
+      const output: SyncHookJSONOutput = {
+        decision: 'block',
+        reason: 'Potentially dangerous operation',
+        stopReason: 'Security policy violation',
+      };
+
+      expect(output.decision).toBe('block');
+    });
+  });
+
+  describe('HookCallbackMatcher', () => {
+    it('should support matcher with hooks', () => {
+      const hookCallback: HookCallback = async (input, toolUseId, opts) => {
+        return { continue: true };
+      };
+
+      const matcher: HookCallbackMatcher = {
+        matcher: 'Bash*',
+        hooks: [hookCallback],
+        timeout: 60,
+      };
+
+      expect(matcher.matcher).toBe('Bash*');
+      expect(matcher.hooks).toHaveLength(1);
+      expect(matcher.timeout).toBe(60);
+    });
+
+    it('should support matcher without pattern (matches all)', () => {
+      const matcher: HookCallbackMatcher = {
+        hooks: [async () => ({ continue: true })],
+      };
+
+      expect(matcher.matcher).toBeUndefined();
+      expect(matcher.hooks).toHaveLength(1);
+    });
+
+    it('should support multiple hooks', () => {
+      const hook1: HookCallback = async () => ({ continue: true });
+      const hook2: HookCallback = async () => ({
+        continue: true,
+        systemMessage: 'Logged',
+      });
+      const hook3: HookCallback = async () => ({ decision: 'approve' });
+
+      const matcher: HookCallbackMatcher = {
+        hooks: [hook1, hook2, hook3],
+      };
+
+      expect(matcher.hooks).toHaveLength(3);
+    });
+  });
+
+  describe('Hook Callback Execution', () => {
+    it('should execute hook callback with proper arguments', async () => {
+      let receivedInput: HookInput | null = null;
+      let receivedToolUseId: string | undefined = undefined;
+      let signalReceived = false;
+
+      const hookCallback: HookCallback = async (input, toolUseId, opts) => {
+        receivedInput = input;
+        receivedToolUseId = toolUseId;
+        signalReceived = opts.signal !== undefined;
+        return { continue: true };
+      };
+
+      const testInput: PreToolUseHookInput = {
+        hook_event_name: 'PreToolUse',
+        session_id: 'session-123',
+        transcript_path: '/tmp/transcript.json',
+        cwd: '/home/user/project',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo hello' },
+        tool_use_id: 'tool-123',
+      };
+
+      const abortController = new AbortController();
+      const result = await hookCallback(testInput, 'tool-123', {
+        signal: abortController.signal,
+      });
+
+      expect(receivedInput).toEqual(testInput);
+      expect(receivedToolUseId).toBe('tool-123');
+      expect(signalReceived).toBe(true);
+      expect(result).toEqual({ continue: true });
+    });
+
+    it('should handle async hook that blocks', async () => {
+      const blockingHook: HookCallback = async () => ({
+        decision: 'block',
+        reason: 'Operation not allowed',
+      });
+
+      const result = await blockingHook(
+        {} as HookInput,
+        'tool-123',
+        { signal: new AbortController().signal }
+      );
+
+      expect(result).toEqual({
+        decision: 'block',
+        reason: 'Operation not allowed',
+      });
+    });
+
+    it('should handle hook that modifies input', async () => {
+      const modifyingHook: HookCallback = async (input) => ({
+        continue: true,
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          updatedInput: { command: 'safe-command' },
+        },
+      });
+
+      const result = await modifyingHook(
+        {} as HookInput,
+        undefined,
+        { signal: new AbortController().signal }
+      );
+
+      expect(result).toHaveProperty('hookSpecificOutput');
+    });
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for MCP server creation functionality
+ */
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { createSdkMcpServer, tool } from '@anthropic-ai/claude-agent-sdk';
+
+describe('MCP Server Creation', () => {
+  describe('createSdkMcpServer', () => {
+    it('should create a basic MCP server with name', () => {
+      const server = createSdkMcpServer({
+        name: 'test-server',
+      });
+
+      expect(server).toBeDefined();
+      expect(server.type).toBe('sdk');
+      expect(server.name).toBe('test-server');
+      expect(server.instance).toBeDefined();
+    });
+
+    it('should create a server with version', () => {
+      const server = createSdkMcpServer({
+        name: 'test-server',
+        version: '1.0.0',
+      });
+
+      expect(server).toBeDefined();
+      expect(server.type).toBe('sdk');
+      expect(server.name).toBe('test-server');
+    });
+
+    it('should create a server with tools', () => {
+      const greetTool = tool(
+        'greet',
+        'Greet a user by name',
+        { name: z.string().describe('Name to greet') },
+        async (args) => ({
+          content: [{ type: 'text', text: `Hello, ${args.name}!` }],
+        })
+      );
+
+      const server = createSdkMcpServer({
+        name: 'greeting-server',
+        tools: [greetTool],
+      });
+
+      expect(server).toBeDefined();
+      expect(server.type).toBe('sdk');
+      expect(server.name).toBe('greeting-server');
+    });
+  });
+
+  describe('tool helper', () => {
+    it('should create a tool definition with required properties', () => {
+      const testTool = tool(
+        'test-tool',
+        'A test tool',
+        { input: z.string() },
+        async (args) => ({
+          content: [{ type: 'text', text: `Input: ${args.input}` }],
+        })
+      );
+
+      expect(testTool).toBeDefined();
+      expect(testTool.name).toBe('test-tool');
+      expect(testTool.description).toBe('A test tool');
+      expect(testTool.inputSchema).toBeDefined();
+      expect(testTool.handler).toBeDefined();
+      expect(typeof testTool.handler).toBe('function');
+    });
+
+    it('should create a tool with complex schema', () => {
+      const complexTool = tool(
+        'complex-tool',
+        'A tool with complex input',
+        {
+          required_field: z.string(),
+          optional_field: z.number().optional(),
+          enum_field: z.enum(['a', 'b', 'c']),
+          array_field: z.array(z.string()),
+        },
+        async (args) => ({
+          content: [{ type: 'text', text: JSON.stringify(args) }],
+        })
+      );
+
+      expect(complexTool).toBeDefined();
+      expect(complexTool.name).toBe('complex-tool');
+      expect(complexTool.inputSchema).toBeDefined();
+    });
+
+    it('should create a tool that can be invoked', async () => {
+      const addTool = tool(
+        'add',
+        'Add two numbers',
+        {
+          a: z.number(),
+          b: z.number(),
+        },
+        async (args) => ({
+          content: [{ type: 'text', text: String(args.a + args.b) }],
+        })
+      );
+
+      const result = await addTool.handler({ a: 2, b: 3 }, {});
+      expect(result.content).toBeDefined();
+      expect(result.content[0]).toEqual({ type: 'text', text: '5' });
+    });
+
+    it('should handle async tool handlers', async () => {
+      const asyncTool = tool(
+        'async-tool',
+        'An async tool',
+        { delay: z.number() },
+        async (args) => {
+          await new Promise((resolve) => setTimeout(resolve, args.delay));
+          return {
+            content: [{ type: 'text', text: `Waited ${args.delay}ms` }],
+          };
+        }
+      );
+
+      const start = Date.now();
+      const result = await asyncTool.handler({ delay: 50 }, {});
+      const elapsed = Date.now() - start;
+
+      expect(elapsed).toBeGreaterThanOrEqual(50);
+      expect(result.content[0]).toEqual({ type: 'text', text: 'Waited 50ms' });
+    });
+
+    it('should handle tool errors', async () => {
+      const errorTool = tool(
+        'error-tool',
+        'A tool that throws',
+        { shouldError: z.boolean() },
+        async (args) => {
+          if (args.shouldError) {
+            throw new Error('Tool error');
+          }
+          return { content: [{ type: 'text', text: 'Success' }] };
+        }
+      );
+
+      await expect(errorTool.handler({ shouldError: true }, {})).rejects.toThrow(
+        'Tool error'
+      );
+
+      const successResult = await errorTool.handler({ shouldError: false }, {});
+      expect(successResult.content[0]).toEqual({ type: 'text', text: 'Success' });
+    });
+  });
+
+  describe('Multiple tools in server', () => {
+    it('should create a server with multiple tools', () => {
+      const tool1 = tool(
+        'tool1',
+        'First tool',
+        { input: z.string() },
+        async () => ({ content: [{ type: 'text', text: 'tool1' }] })
+      );
+
+      const tool2 = tool(
+        'tool2',
+        'Second tool',
+        { input: z.number() },
+        async () => ({ content: [{ type: 'text', text: 'tool2' }] })
+      );
+
+      const tool3 = tool(
+        'tool3',
+        'Third tool',
+        { input: z.boolean() },
+        async () => ({ content: [{ type: 'text', text: 'tool3' }] })
+      );
+
+      const server = createSdkMcpServer({
+        name: 'multi-tool-server',
+        version: '1.0.0',
+        tools: [tool1, tool2, tool3],
+      });
+
+      expect(server).toBeDefined();
+      expect(server.type).toBe('sdk');
+      expect(server.name).toBe('multi-tool-server');
+    });
+  });
+});

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,0 +1,495 @@
+/**
+ * Tests for SDK message types
+ */
+import { describe, it, expect } from 'vitest';
+import type {
+  SDKMessage,
+  SDKUserMessage,
+  SDKAssistantMessage,
+  SDKResultMessage,
+  SDKSystemMessage,
+  SDKPartialAssistantMessage,
+  SDKCompactBoundaryMessage,
+  SDKStatusMessage,
+  SDKHookResponseMessage,
+  SDKToolProgressMessage,
+  SDKAuthStatusMessage,
+  SDKUserMessageReplay,
+  SDKPermissionDenial,
+  SDKAssistantMessageError,
+} from '@anthropic-ai/claude-agent-sdk';
+
+describe('SDK Message Types', () => {
+  describe('SDKUserMessage', () => {
+    it('should support user message structure', () => {
+      const message: SDKUserMessage = {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'Hello, Claude!',
+        },
+        parent_tool_use_id: null,
+        session_id: 'session-123',
+      };
+
+      expect(message.type).toBe('user');
+      expect(message.parent_tool_use_id).toBeNull();
+    });
+
+    it('should support synthetic user message', () => {
+      const message: SDKUserMessage = {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'Tool result placeholder',
+        },
+        parent_tool_use_id: 'tool-123',
+        isSynthetic: true,
+        session_id: 'session-123',
+      };
+
+      expect(message.isSynthetic).toBe(true);
+      expect(message.parent_tool_use_id).toBe('tool-123');
+    });
+
+    it('should support tool_use_result', () => {
+      const message: SDKUserMessage = {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'tool-123',
+              content: 'Success',
+            },
+          ],
+        },
+        parent_tool_use_id: 'tool-123',
+        tool_use_result: { status: 'success', output: 'File created' },
+        session_id: 'session-123',
+      };
+
+      expect(message.tool_use_result).toEqual({
+        status: 'success',
+        output: 'File created',
+      });
+    });
+  });
+
+  describe('SDKUserMessageReplay', () => {
+    it('should have isReplay set to true', () => {
+      const message: SDKUserMessageReplay = {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'Original message',
+        },
+        parent_tool_use_id: null,
+        uuid: 'uuid-123' as any,
+        session_id: 'session-123',
+        isReplay: true,
+      };
+
+      expect(message.isReplay).toBe(true);
+    });
+  });
+
+  describe('SDKAssistantMessage', () => {
+    it('should support assistant message structure', () => {
+      const message: SDKAssistantMessage = {
+        type: 'assistant',
+        message: {
+          id: 'msg-123',
+          type: 'message',
+          role: 'assistant',
+          content: [
+            {
+              type: 'text',
+              text: 'Hello! How can I help you?',
+            },
+          ],
+          model: 'claude-sonnet-4-5-20250929',
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 20,
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: 'uuid-456' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.type).toBe('assistant');
+      expect(message.message.role).toBe('assistant');
+    });
+
+    it('should support error field', () => {
+      const errorTypes: SDKAssistantMessageError[] = [
+        'authentication_failed',
+        'billing_error',
+        'rate_limit',
+        'invalid_request',
+        'server_error',
+        'unknown',
+      ];
+
+      for (const error of errorTypes) {
+        const message: SDKAssistantMessage = {
+          type: 'assistant',
+          message: {} as any,
+          parent_tool_use_id: null,
+          error,
+          uuid: 'uuid-789' as any,
+          session_id: 'session-123',
+        };
+
+        expect(message.error).toBe(error);
+      }
+    });
+  });
+
+  describe('SDKResultMessage', () => {
+    it('should support success result', () => {
+      const message: SDKResultMessage = {
+        type: 'result',
+        subtype: 'success',
+        duration_ms: 5000,
+        duration_api_ms: 4500,
+        is_error: false,
+        num_turns: 3,
+        result: 'Task completed successfully',
+        total_cost_usd: 0.05,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 200,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+        modelUsage: {
+          'claude-sonnet-4-5-20250929': {
+            inputTokens: 100,
+            outputTokens: 200,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0.05,
+            contextWindow: 200000,
+          },
+        },
+        permission_denials: [],
+        uuid: 'uuid-result' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.subtype).toBe('success');
+      expect(message.is_error).toBe(false);
+      expect(message.result).toBe('Task completed successfully');
+    });
+
+    it('should support error result types', () => {
+      const errorSubtypes: Array<
+        | 'error_during_execution'
+        | 'error_max_turns'
+        | 'error_max_budget_usd'
+        | 'error_max_structured_output_retries'
+      > = [
+        'error_during_execution',
+        'error_max_turns',
+        'error_max_budget_usd',
+        'error_max_structured_output_retries',
+      ];
+
+      for (const subtype of errorSubtypes) {
+        const message: SDKResultMessage = {
+          type: 'result',
+          subtype,
+          duration_ms: 1000,
+          duration_api_ms: 900,
+          is_error: true,
+          num_turns: 1,
+          total_cost_usd: 0.01,
+          usage: {
+            input_tokens: 50,
+            output_tokens: 10,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          modelUsage: {},
+          permission_denials: [],
+          errors: ['An error occurred'],
+          uuid: 'uuid-error' as any,
+          session_id: 'session-123',
+        };
+
+        expect(message.subtype).toBe(subtype);
+        expect(message.is_error).toBe(true);
+      }
+    });
+
+    it('should support permission denials', () => {
+      const denial: SDKPermissionDenial = {
+        tool_name: 'Bash',
+        tool_use_id: 'tool-123',
+        tool_input: { command: 'rm -rf /' },
+      };
+
+      const message: SDKResultMessage = {
+        type: 'result',
+        subtype: 'success',
+        duration_ms: 100,
+        duration_api_ms: 90,
+        is_error: false,
+        num_turns: 1,
+        result: 'Completed with denied operations',
+        total_cost_usd: 0.01,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+        modelUsage: {},
+        permission_denials: [denial],
+        uuid: 'uuid-denial' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.permission_denials).toHaveLength(1);
+      expect(message.permission_denials[0].tool_name).toBe('Bash');
+    });
+
+    it('should support structured output', () => {
+      const message: SDKResultMessage = {
+        type: 'result',
+        subtype: 'success',
+        duration_ms: 500,
+        duration_api_ms: 450,
+        is_error: false,
+        num_turns: 1,
+        result: '{"answer": "42", "confidence": 0.95}',
+        total_cost_usd: 0.02,
+        usage: {
+          input_tokens: 20,
+          output_tokens: 15,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+        modelUsage: {},
+        permission_denials: [],
+        structured_output: { answer: '42', confidence: 0.95 },
+        uuid: 'uuid-structured' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.structured_output).toEqual({
+        answer: '42',
+        confidence: 0.95,
+      });
+    });
+  });
+
+  describe('SDKSystemMessage', () => {
+    it('should support init system message', () => {
+      const message: SDKSystemMessage = {
+        type: 'system',
+        subtype: 'init',
+        apiKeySource: 'user',
+        claude_code_version: '2.0.61',
+        cwd: '/home/user/project',
+        tools: ['Bash', 'Read', 'Edit', 'Write', 'Glob', 'Grep'],
+        mcp_servers: [
+          { name: 'my-server', status: 'connected' },
+          { name: 'other-server', status: 'failed' },
+        ],
+        model: 'claude-sonnet-4-5-20250929',
+        permissionMode: 'default',
+        slash_commands: ['review', 'test', 'deploy'],
+        output_style: 'default',
+        skills: ['code-review', 'test-runner'],
+        plugins: [{ name: 'my-plugin', path: './plugins/my-plugin' }],
+        uuid: 'uuid-system' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.type).toBe('system');
+      expect(message.subtype).toBe('init');
+      expect(message.tools).toContain('Bash');
+    });
+
+    it('should support optional agents and betas', () => {
+      const message: SDKSystemMessage = {
+        type: 'system',
+        subtype: 'init',
+        agents: ['code-reviewer', 'test-runner'],
+        betas: ['context-1m-2025-08-07'],
+        apiKeySource: 'project',
+        claude_code_version: '2.0.61',
+        cwd: '/home/user/project',
+        tools: [],
+        mcp_servers: [],
+        model: 'claude-sonnet-4-5-20250929',
+        permissionMode: 'acceptEdits',
+        slash_commands: [],
+        output_style: 'streaming',
+        skills: [],
+        plugins: [],
+        uuid: 'uuid-system-2' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.agents).toEqual(['code-reviewer', 'test-runner']);
+      expect(message.betas).toEqual(['context-1m-2025-08-07']);
+    });
+  });
+
+  describe('SDKPartialAssistantMessage', () => {
+    it('should support stream event', () => {
+      const message: SDKPartialAssistantMessage = {
+        type: 'stream_event',
+        event: {
+          type: 'content_block_delta',
+          index: 0,
+          delta: {
+            type: 'text_delta',
+            text: 'Hello',
+          },
+        },
+        parent_tool_use_id: null,
+        uuid: 'uuid-partial' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.type).toBe('stream_event');
+      expect(message.event.type).toBe('content_block_delta');
+    });
+  });
+
+  describe('SDKCompactBoundaryMessage', () => {
+    it('should support compact boundary', () => {
+      const message: SDKCompactBoundaryMessage = {
+        type: 'system',
+        subtype: 'compact_boundary',
+        compact_metadata: {
+          trigger: 'auto',
+          pre_tokens: 150000,
+        },
+        uuid: 'uuid-compact' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.subtype).toBe('compact_boundary');
+      expect(message.compact_metadata.trigger).toBe('auto');
+    });
+
+    it('should support manual trigger', () => {
+      const message: SDKCompactBoundaryMessage = {
+        type: 'system',
+        subtype: 'compact_boundary',
+        compact_metadata: {
+          trigger: 'manual',
+          pre_tokens: 50000,
+        },
+        uuid: 'uuid-compact-manual' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.compact_metadata.trigger).toBe('manual');
+    });
+  });
+
+  describe('SDKStatusMessage', () => {
+    it('should support compacting status', () => {
+      const message: SDKStatusMessage = {
+        type: 'system',
+        subtype: 'status',
+        status: 'compacting',
+        uuid: 'uuid-status' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.subtype).toBe('status');
+      expect(message.status).toBe('compacting');
+    });
+
+    it('should support null status', () => {
+      const message: SDKStatusMessage = {
+        type: 'system',
+        subtype: 'status',
+        status: null,
+        uuid: 'uuid-status-null' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.status).toBeNull();
+    });
+  });
+
+  describe('SDKHookResponseMessage', () => {
+    it('should support hook response', () => {
+      const message: SDKHookResponseMessage = {
+        type: 'system',
+        subtype: 'hook_response',
+        hook_name: 'my-hook',
+        hook_event: 'PreToolUse',
+        stdout: 'Hook output',
+        stderr: '',
+        exit_code: 0,
+        uuid: 'uuid-hook' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.subtype).toBe('hook_response');
+      expect(message.hook_name).toBe('my-hook');
+      expect(message.exit_code).toBe(0);
+    });
+  });
+
+  describe('SDKToolProgressMessage', () => {
+    it('should support tool progress', () => {
+      const message: SDKToolProgressMessage = {
+        type: 'tool_progress',
+        tool_use_id: 'tool-123',
+        tool_name: 'Bash',
+        parent_tool_use_id: null,
+        elapsed_time_seconds: 5.5,
+        uuid: 'uuid-progress' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.type).toBe('tool_progress');
+      expect(message.elapsed_time_seconds).toBe(5.5);
+    });
+  });
+
+  describe('SDKAuthStatusMessage', () => {
+    it('should support auth status', () => {
+      const message: SDKAuthStatusMessage = {
+        type: 'auth_status',
+        isAuthenticating: true,
+        output: ['Authenticating...', 'Please wait'],
+        uuid: 'uuid-auth' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.type).toBe('auth_status');
+      expect(message.isAuthenticating).toBe(true);
+      expect(message.output).toHaveLength(2);
+    });
+
+    it('should support auth error', () => {
+      const message: SDKAuthStatusMessage = {
+        type: 'auth_status',
+        isAuthenticating: false,
+        output: ['Authentication failed'],
+        error: 'Invalid API key',
+        uuid: 'uuid-auth-error' as any,
+        session_id: 'session-123',
+      };
+
+      expect(message.error).toBe('Invalid API key');
+    });
+  });
+});

--- a/tests/process-transport-write-after-end.test.ts
+++ b/tests/process-transport-write-after-end.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Regression test for issue #148:
+ * "Race condition: writes after endInput() cause ERR_STREAM_WRITE_AFTER_END"
+ *
+ * Root cause: ProcessTransport.endInput() calls processStdin.end() but leaves
+ * this.ready = true and this.processStdin set. In single-turn mode the SDK calls
+ * endInput() when the first `result` message is received. Because
+ * handleControlRequest() is NOT awaited in the readMessages loop, an in-flight
+ * control handler can still call transport.write() after stdin is ended.
+ *
+ * That write() passes all existing guards, reaches processStdin.write() on a
+ * closed Writable, and throws ERR_STREAM_WRITE_AFTER_END. The handleControlRequest
+ * catch block then tries a second write() (the error response), which also throws
+ * — as an UNHANDLED rejection that crashes Node.js.
+ *
+ * The fix: add a stdinEnded guard as the very first check in write():
+ *
+ *   private stdinEnded = false;
+ *
+ *   endInput(): void {
+ *     this.stdinEnded = true;          // ← NEW: set BEFORE calling .end()
+ *     if (this.processStdin) this.processStdin.end();
+ *   }
+ *
+ *   write(data: string): void {
+ *     if (this.stdinEnded) return;     // ← NEW: silent drop, never throws
+ *     // ... rest of existing guards unchanged ...
+ *   }
+ *
+ * Silent drop is safe because after endInput() the subprocess has already emitted
+ * its `result` message and will not read any further stdin data.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { PassThrough } from 'stream';
+import { EventEmitter } from 'events';
+import { query, AbortError } from '@anthropic-ai/claude-agent-sdk';
+import type { SpawnedProcess, SpawnOptions } from '@anthropic-ai/claude-agent-sdk';
+
+/** Minimal SpawnedProcess that lets the test control stdin/stdout. */
+function createMockProcess() {
+  const stdin = new PassThrough();
+  const stdout = new PassThrough();
+  const emitter = new EventEmitter();
+  let killed = false;
+  let exitCode: number | null = null;
+
+  const proc = {
+    stdin,
+    stdout,
+    get killed() { return killed; },
+    get exitCode() { return exitCode; },
+    kill(_signal?: NodeJS.Signals): boolean { killed = true; return true; },
+    on(event: 'exit' | 'error', listener: (...args: unknown[]) => void): void {
+      emitter.on(event, listener);
+    },
+    once(event: 'exit' | 'error', listener: (...args: unknown[]) => void): void {
+      emitter.once(event, listener);
+    },
+    off(event: 'exit' | 'error', listener: (...args: unknown[]) => void): void {
+      emitter.off(event, listener);
+    },
+    triggerExit(code: number | null, signal: NodeJS.Signals | null = null): void {
+      exitCode = code;
+      killed = signal != null;
+      emitter.emit('exit', code, signal);
+    },
+  } satisfies SpawnedProcess & { stdin: PassThrough; stdout: PassThrough; triggerExit: Function };
+
+  // Auto-respond to the SDK's initialize control_request so the SDK becomes ready.
+  // The SDK writes {"type":"control_request","request":{"subtype":"initialize"},...}
+  // and waits for {"type":"control_response","response":{"subtype":"success",...}}.
+  let stdinBuffer = '';
+  stdin.on('data', (chunk: Buffer) => {
+    stdinBuffer += chunk.toString();
+    const lines = stdinBuffer.split('\n');
+    stdinBuffer = lines.pop() ?? ''; // keep incomplete last line
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      try {
+        const msg = JSON.parse(line) as { type: string; request_id: string; request: { subtype: string } };
+        if (msg.type === 'control_request' && msg.request?.subtype === 'initialize') {
+          const resp = JSON.stringify({
+            type: 'control_response',
+            response: { subtype: 'success', request_id: msg.request_id, response: {} },
+          });
+          stdout.push(resp + '\n');
+        }
+      } catch {
+        // ignore non-JSON or partial lines
+      }
+    }
+  });
+
+  return proc;
+}
+
+describe('ProcessTransport write-after-endInput race condition (issue #148)', () => {
+  it(
+    'should not produce unhandled rejections when a control handler writes after endInput()',
+    async () => {
+      /**
+       * Reproduces the exact race:
+       *
+       *   t=0ms  : SDK spawns, sends initialize → mock responds → SDK ready
+       *   t=50ms : control_request arrives → handleControlRequest() starts (NOT awaited)
+       *            canUseTool waits 60ms before returning
+       *   t=50ms : result message arrives → endInput() → processStdin.end()
+       *   t=110ms: canUseTool resolves → handleControlRequest tries write()
+       *            ← without fix: ERR_STREAM_WRITE_AFTER_END → unhandled rejection
+       *            ← with fix: stdinEnded guard returns silently → no crash
+       */
+      const unhandledErrors: Error[] = [];
+      const onUnhandled = (reason: unknown) => {
+        if (reason instanceof Error) unhandledErrors.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandled);
+
+      const spawnCalled = vi.fn();
+      let mockProc: ReturnType<typeof createMockProcess> | null = null;
+
+      // canUseTool introduces a 60ms delay so the result message + endInput()
+      // runs before the control handler tries to write its response.
+      const canUseTool = vi.fn(async (_toolName: string) => {
+        await new Promise<void>((r) => setTimeout(r, 60));
+        return { behavior: 'allow' as const };
+      });
+
+      const abortController = new AbortController();
+
+      // query() takes a single {prompt, options} object — NOT positional args
+      const queryIterator = query({
+        prompt: 'test prompt',
+        options: {
+          pathToClaudeCodeExecutable: 'node', // ignored when spawnClaudeCodeProcess is set
+          spawnClaudeCodeProcess: (_options: SpawnOptions): SpawnedProcess => {
+            spawnCalled();
+            mockProc = createMockProcess();
+            return mockProc;
+          },
+          canUseTool,
+          abortController,
+        },
+      });
+
+      // IMPORTANT: start consuming the iterator immediately — this is what
+      // triggers the lazy spawn. The agent's original test waited 50ms before
+      // consuming, so spawnClaudeCodeProcess was never called.
+      const drainDone = (async () => {
+        try {
+          for await (const _msg of queryIterator) { /* consume */ }
+        } catch (err) {
+          if (err instanceof AbortError) return;
+          // Expected: "not valid JSON", "process exited", etc from mock mismatch
+        }
+      })();
+
+      // Wait for the SDK to spawn and complete the initialize handshake
+      await new Promise<void>((r) => setTimeout(r, 50));
+      expect(spawnCalled).toHaveBeenCalledOnce();
+      expect(mockProc).not.toBeNull();
+      const proc = mockProc!;
+
+      // Push the race scenario messages back-to-back:
+      // 1. control_request  → handleControlRequest() fires async (not awaited)
+      // 2. result           → endInput() called immediately after
+      proc.stdout.push(
+        JSON.stringify({
+          type: 'control_request',
+          request_id: 'race-148',
+          request: {
+            subtype: 'can_use_tool',
+            tool_name: 'Bash',
+            input: { command: 'echo hi' },
+            tool_use_id: 'tu-001',
+          },
+        }) + '\n'
+      );
+      proc.stdout.push(
+        JSON.stringify({
+          type: 'result',
+          subtype: 'success',
+          is_error: false,
+          result: '',
+          session_id: 'sess-148',
+          cost_usd: 0,
+          duration_ms: 10,
+          duration_api_ms: 5,
+          num_turns: 1,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }) + '\n'
+      );
+      proc.stdout.push(null); // EOF — closes the readMessages loop
+      proc.triggerExit(0, null); // unblock ProcessTransport.waitForExit()
+
+      // Wait well past the canUseTool delay so the in-flight write attempt executes
+      await new Promise<void>((r) => setTimeout(r, 200));
+
+      abortController.abort();
+      await drainDone;
+
+      process.off('unhandledRejection', onUnhandled);
+
+      const streamErrors = unhandledErrors.filter(
+        (e) =>
+          (e as NodeJS.ErrnoException).code === 'ERR_STREAM_WRITE_AFTER_END' ||
+          e.message.includes('write after end') ||
+          e.message.includes('Failed to write to process stdin') ||
+          e.message.includes('ProcessTransport is not ready for writing')
+      );
+
+      expect(
+        streamErrors,
+        `Unexpected write-after-end errors (bug not fixed): ${streamErrors.map((e) => e.message).join(', ')}`
+      ).toHaveLength(0);
+    },
+    5000
+  );
+
+  it('confirms stdin.writableEnded is set synchronously by .end() — the invariant the fix relies on', () => {
+    /**
+     * The stdinEnded fix sets the flag BEFORE calling processStdin.end().
+     * This test documents that .end() sets writableEnded synchronously,
+     * so either approach (explicit flag OR checking writableEnded) would work.
+     * The explicit flag is preferred because it does not rely on stream internals.
+     */
+    const stdin = new PassThrough();
+    expect(stdin.writableEnded).toBe(false);
+    stdin.end();
+    expect(stdin.writableEnded).toBe(true);
+  });
+});

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for query function behavior
+ * Note: These tests don't make actual API calls - they test the function
+ * signature and behavior without an API key.
+ */
+import { describe, it, expect } from 'vitest';
+import { query, AbortError } from '@anthropic-ai/claude-agent-sdk';
+import type { Options, Query } from '@anthropic-ai/claude-agent-sdk';
+
+describe('Query Function', () => {
+  describe('Function signature', () => {
+    it('should accept a string prompt', () => {
+      // Verify the function accepts the expected parameters
+      // We don't execute as it would require an API key
+      expect(typeof query).toBe('function');
+
+      // Check function accepts correct parameter structure
+      const params = {
+        prompt: 'Hello, world!',
+      };
+      expect(params.prompt).toBe('Hello, world!');
+    });
+
+    it('should accept options parameter', () => {
+      const options: Options = {
+        model: 'claude-sonnet-4-5-20250929',
+        maxTurns: 5,
+        cwd: '/tmp',
+      };
+
+      const params = {
+        prompt: 'Test prompt',
+        options,
+      };
+
+      expect(params.options).toBe(options);
+      expect(params.options.model).toBe('claude-sonnet-4-5-20250929');
+    });
+
+    it('should accept AbortController in options', () => {
+      const abortController = new AbortController();
+      const options: Options = {
+        abortController,
+      };
+
+      expect(options.abortController).toBe(abortController);
+      expect(options.abortController?.signal.aborted).toBe(false);
+    });
+  });
+
+  describe('AbortError', () => {
+    it('should be throwable', () => {
+      expect(() => {
+        throw new AbortError('Operation aborted');
+      }).toThrow(AbortError);
+    });
+
+    it('should be an instance of AbortError', () => {
+      const error = new AbortError('test');
+      expect(error).toBeInstanceOf(AbortError);
+      expect(error).toBeInstanceOf(Error);
+    });
+
+    it('should preserve error message', () => {
+      const error = new AbortError('Custom abort message');
+      expect(error.message).toBe('Custom abort message');
+    });
+
+    it('should be catchable as Error', () => {
+      try {
+        throw new AbortError('test');
+      } catch (e) {
+        expect(e).toBeInstanceOf(Error);
+        expect(e).toBeInstanceOf(AbortError);
+      }
+    });
+  });
+
+  describe('Options validation', () => {
+    it('should allow bypassing permissions with flag', () => {
+      const options: Options = {
+        permissionMode: 'bypassPermissions',
+        allowDangerouslySkipPermissions: true,
+      };
+
+      expect(options.permissionMode).toBe('bypassPermissions');
+      expect(options.allowDangerouslySkipPermissions).toBe(true);
+    });
+
+    it('should allow configuring MCP servers', () => {
+      const options: Options = {
+        mcpServers: {
+          'my-server': {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      };
+
+      expect(options.mcpServers).toBeDefined();
+      expect(options.mcpServers?.['my-server']).toBeDefined();
+    });
+
+    it('should allow configuring agents', () => {
+      const options: Options = {
+        agents: {
+          'code-reviewer': {
+            description: 'Reviews code for bugs',
+            prompt: 'You are a code reviewer.',
+            tools: ['Read', 'Grep'],
+          },
+        },
+      };
+
+      expect(options.agents).toBeDefined();
+      expect(options.agents?.['code-reviewer']).toBeDefined();
+      expect(options.agents?.['code-reviewer'].tools).toEqual(['Read', 'Grep']);
+    });
+
+    it('should allow configuring hooks', () => {
+      const options: Options = {
+        hooks: {
+          PreToolUse: [
+            {
+              matcher: 'Bash',
+              hooks: [
+                async (input, toolUseId, opts) => {
+                  return { continue: true };
+                },
+              ],
+            },
+          ],
+        },
+      };
+
+      expect(options.hooks).toBeDefined();
+      expect(options.hooks?.PreToolUse).toBeDefined();
+      expect(options.hooks?.PreToolUse?.length).toBe(1);
+    });
+
+    it('should allow output format configuration', () => {
+      const options: Options = {
+        outputFormat: {
+          type: 'json_schema',
+          schema: {
+            type: 'object',
+            properties: {
+              answer: { type: 'string' },
+              confidence: { type: 'number' },
+            },
+          },
+        },
+      };
+
+      expect(options.outputFormat).toBeDefined();
+      expect(options.outputFormat?.type).toBe('json_schema');
+    });
+
+    it('should allow resume and fork session options', () => {
+      const options: Options = {
+        resume: 'session-123',
+        forkSession: true,
+      };
+
+      expect(options.resume).toBe('session-123');
+      expect(options.forkSession).toBe(true);
+    });
+
+    it('should allow continue option', () => {
+      const options: Options = {
+        continue: true,
+      };
+
+      expect(options.continue).toBe(true);
+    });
+
+    it('should allow additional directories', () => {
+      const options: Options = {
+        additionalDirectories: ['/home/user/projects', '/var/log'],
+      };
+
+      expect(options.additionalDirectories).toEqual([
+        '/home/user/projects',
+        '/var/log',
+      ]);
+    });
+
+    it('should allow env configuration', () => {
+      const options: Options = {
+        env: {
+          NODE_ENV: 'test',
+          DEBUG: 'true',
+          UNDEFINED_VAR: undefined,
+        },
+      };
+
+      expect(options.env?.NODE_ENV).toBe('test');
+      expect(options.env?.DEBUG).toBe('true');
+      expect(options.env?.UNDEFINED_VAR).toBeUndefined();
+    });
+
+    it('should allow executable configuration', () => {
+      const options: Options = {
+        executable: 'node',
+        executableArgs: ['--max-old-space-size=4096'],
+      };
+
+      expect(options.executable).toBe('node');
+      expect(options.executableArgs).toEqual(['--max-old-space-size=4096']);
+    });
+
+    it('should allow extra CLI args', () => {
+      const options: Options = {
+        extraArgs: {
+          verbose: null, // boolean flag
+          output: '/tmp/output.json',
+        },
+      };
+
+      expect(options.extraArgs?.verbose).toBeNull();
+      expect(options.extraArgs?.output).toBe('/tmp/output.json');
+    });
+
+    it('should allow fallback model', () => {
+      const options: Options = {
+        model: 'claude-opus-4-20250514',
+        fallbackModel: 'claude-sonnet-4-5-20250929',
+      };
+
+      expect(options.fallbackModel).toBe('claude-sonnet-4-5-20250929');
+    });
+
+    it('should allow max thinking tokens', () => {
+      const options: Options = {
+        maxThinkingTokens: 10000,
+      };
+
+      expect(options.maxThinkingTokens).toBe(10000);
+    });
+
+    it('should allow permission prompt tool name', () => {
+      const options: Options = {
+        permissionPromptToolName: 'mcp__my-server__permission_prompt',
+      };
+
+      expect(options.permissionPromptToolName).toBe(
+        'mcp__my-server__permission_prompt'
+      );
+    });
+
+    it('should allow stderr callback', () => {
+      const stderrData: string[] = [];
+      const options: Options = {
+        stderr: (data) => stderrData.push(data),
+      };
+
+      expect(options.stderr).toBeDefined();
+      options.stderr?.('test error');
+      expect(stderrData).toEqual(['test error']);
+    });
+
+    it('should allow strict MCP config', () => {
+      const options: Options = {
+        strictMcpConfig: true,
+      };
+
+      expect(options.strictMcpConfig).toBe(true);
+    });
+
+    it('should allow include partial messages', () => {
+      const options: Options = {
+        includePartialMessages: true,
+      };
+
+      expect(options.includePartialMessages).toBe(true);
+    });
+
+    it('should allow sandbox configuration', () => {
+      const options: Options = {
+        sandbox: {
+          enabled: true,
+        },
+      };
+
+      expect(options.sandbox?.enabled).toBe(true);
+    });
+
+    it('should allow plugins configuration', () => {
+      const options: Options = {
+        plugins: [
+          { type: 'local', path: './my-plugin' },
+          { type: 'local', path: '/absolute/path/to/plugin' },
+        ],
+      };
+
+      expect(options.plugins).toHaveLength(2);
+      expect(options.plugins?.[0].type).toBe('local');
+    });
+
+    it('should allow canUseTool callback', () => {
+      const options: Options = {
+        canUseTool: async (toolName, input, opts) => {
+          if (toolName === 'Bash') {
+            return {
+              behavior: 'deny',
+              message: 'Bash not allowed',
+            };
+          }
+          return {
+            behavior: 'allow',
+            updatedInput: input,
+          };
+        },
+      };
+
+      expect(options.canUseTool).toBeDefined();
+    });
+
+    it('should allow resume session at specific message', () => {
+      const options: Options = {
+        resume: 'session-123',
+        resumeSessionAt: 'message-uuid-456',
+      };
+
+      expect(options.resume).toBe('session-123');
+      expect(options.resumeSessionAt).toBe('message-uuid-456');
+    });
+  });
+});

--- a/tests/types.test.ts
+++ b/tests/types.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for type definitions and type safety
+ * These tests verify that TypeScript types are correctly exported and usable.
+ */
+import { describe, it, expect } from 'vitest';
+import type {
+  Options,
+  Query,
+  SDKMessage,
+  SDKUserMessage,
+  SDKAssistantMessage,
+  SDKResultMessage,
+  SDKSystemMessage,
+  McpServerConfig,
+  McpStdioServerConfig,
+  McpSSEServerConfig,
+  McpHttpServerConfig,
+  McpSdkServerConfig,
+  PermissionMode,
+  PermissionResult,
+  PermissionBehavior,
+  HookEvent,
+  HookInput,
+  HookJSONOutput,
+  AgentDefinition,
+  SettingSource,
+  ModelUsage,
+  OutputFormat,
+  SdkBeta,
+} from '@anthropic-ai/claude-agent-sdk';
+
+describe('Type Definitions', () => {
+  describe('Options type', () => {
+    it('should allow empty options', () => {
+      const options: Options = {};
+      expect(options).toBeDefined();
+    });
+
+    it('should allow cwd option', () => {
+      const options: Options = {
+        cwd: '/path/to/project',
+      };
+      expect(options.cwd).toBe('/path/to/project');
+    });
+
+    it('should allow model option', () => {
+      const options: Options = {
+        model: 'claude-sonnet-4-5-20250929',
+      };
+      expect(options.model).toBe('claude-sonnet-4-5-20250929');
+    });
+
+    it('should allow permission mode options', () => {
+      const modes: PermissionMode[] = [
+        'default',
+        'acceptEdits',
+        'bypassPermissions',
+        'plan',
+        'dontAsk',
+      ];
+
+      for (const mode of modes) {
+        const options: Options = { permissionMode: mode };
+        expect(options.permissionMode).toBe(mode);
+      }
+    });
+
+    it('should allow maxTurns and maxBudgetUsd', () => {
+      const options: Options = {
+        maxTurns: 10,
+        maxBudgetUsd: 5.0,
+      };
+      expect(options.maxTurns).toBe(10);
+      expect(options.maxBudgetUsd).toBe(5.0);
+    });
+
+    it('should allow systemPrompt string', () => {
+      const options: Options = {
+        systemPrompt: 'You are a helpful assistant.',
+      };
+      expect(options.systemPrompt).toBe('You are a helpful assistant.');
+    });
+
+    it('should allow systemPrompt preset', () => {
+      const options: Options = {
+        systemPrompt: {
+          type: 'preset',
+          preset: 'claude_code',
+        },
+      };
+      expect(options.systemPrompt).toEqual({
+        type: 'preset',
+        preset: 'claude_code',
+      });
+    });
+
+    it('should allow systemPrompt preset with append', () => {
+      const options: Options = {
+        systemPrompt: {
+          type: 'preset',
+          preset: 'claude_code',
+          append: 'Additional instructions here.',
+        },
+      };
+      expect(options.systemPrompt).toHaveProperty('append');
+    });
+
+    it('should allow tools configuration', () => {
+      const optionsWithArray: Options = {
+        tools: ['Bash', 'Read', 'Edit'],
+      };
+      expect(optionsWithArray.tools).toEqual(['Bash', 'Read', 'Edit']);
+
+      const optionsWithPreset: Options = {
+        tools: { type: 'preset', preset: 'claude_code' },
+      };
+      expect(optionsWithPreset.tools).toEqual({
+        type: 'preset',
+        preset: 'claude_code',
+      });
+
+      const optionsEmpty: Options = {
+        tools: [],
+      };
+      expect(optionsEmpty.tools).toEqual([]);
+    });
+
+    it('should allow betas configuration', () => {
+      const options: Options = {
+        betas: ['context-1m-2025-08-07'],
+      };
+      expect(options.betas).toEqual(['context-1m-2025-08-07']);
+    });
+
+    it('should allow setting sources', () => {
+      const sources: SettingSource[] = ['user', 'project', 'local'];
+      const options: Options = {
+        settingSources: sources,
+      };
+      expect(options.settingSources).toEqual(sources);
+    });
+  });
+
+  describe('MCP Server Config types', () => {
+    it('should support stdio server config', () => {
+      const config: McpStdioServerConfig = {
+        command: 'node',
+        args: ['server.js'],
+        env: { DEBUG: 'true' },
+      };
+      expect(config.command).toBe('node');
+      expect(config.args).toEqual(['server.js']);
+    });
+
+    it('should support SSE server config', () => {
+      const config: McpSSEServerConfig = {
+        type: 'sse',
+        url: 'https://example.com/sse',
+        headers: { Authorization: 'Bearer token' },
+      };
+      expect(config.type).toBe('sse');
+      expect(config.url).toBe('https://example.com/sse');
+    });
+
+    it('should support HTTP server config', () => {
+      const config: McpHttpServerConfig = {
+        type: 'http',
+        url: 'https://example.com/api',
+        headers: { 'X-API-Key': 'key' },
+      };
+      expect(config.type).toBe('http');
+      expect(config.url).toBe('https://example.com/api');
+    });
+
+    it('should support SDK server config', () => {
+      const config: McpSdkServerConfig = {
+        type: 'sdk',
+        name: 'my-sdk-server',
+      };
+      expect(config.type).toBe('sdk');
+      expect(config.name).toBe('my-sdk-server');
+    });
+  });
+
+  describe('Agent Definition type', () => {
+    it('should allow minimal agent definition', () => {
+      const agent: AgentDefinition = {
+        description: 'A test agent',
+        prompt: 'You are a test agent.',
+      };
+      expect(agent.description).toBe('A test agent');
+      expect(agent.prompt).toBe('You are a test agent.');
+    });
+
+    it('should allow full agent definition', () => {
+      const agent: AgentDefinition = {
+        description: 'A code reviewer agent',
+        prompt: 'Review the code for bugs and style issues.',
+        tools: ['Read', 'Grep', 'Glob'],
+        disallowedTools: ['Bash', 'Edit'],
+        model: 'sonnet',
+      };
+      expect(agent.tools).toEqual(['Read', 'Grep', 'Glob']);
+      expect(agent.disallowedTools).toEqual(['Bash', 'Edit']);
+      expect(agent.model).toBe('sonnet');
+    });
+
+    it('should allow all model types', () => {
+      const models: AgentDefinition['model'][] = [
+        'sonnet',
+        'opus',
+        'haiku',
+        'inherit',
+        undefined,
+      ];
+
+      for (const model of models) {
+        const agent: AgentDefinition = {
+          description: 'test',
+          prompt: 'test',
+          model,
+        };
+        expect(agent.model).toBe(model);
+      }
+    });
+  });
+
+  describe('Permission types', () => {
+    it('should support allow permission result', () => {
+      const result: PermissionResult = {
+        behavior: 'allow',
+        updatedInput: { command: 'ls -la' },
+      };
+      expect(result.behavior).toBe('allow');
+    });
+
+    it('should support deny permission result', () => {
+      const result: PermissionResult = {
+        behavior: 'deny',
+        message: 'Operation not allowed',
+        interrupt: true,
+      };
+      expect(result.behavior).toBe('deny');
+      expect(result.message).toBe('Operation not allowed');
+    });
+
+    it('should support all permission behaviors', () => {
+      const behaviors: PermissionBehavior[] = ['allow', 'deny', 'ask'];
+      expect(behaviors).toHaveLength(3);
+    });
+  });
+
+  describe('Output format types', () => {
+    it('should support json_schema output format', () => {
+      const format: OutputFormat = {
+        type: 'json_schema',
+        schema: {
+          type: 'object',
+          properties: {
+            result: { type: 'string' },
+            score: { type: 'number' },
+          },
+          required: ['result'],
+        },
+      };
+      expect(format.type).toBe('json_schema');
+      expect(format.schema).toBeDefined();
+    });
+  });
+
+  describe('Model Usage type', () => {
+    it('should have all required fields', () => {
+      const usage: ModelUsage = {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadInputTokens: 10,
+        cacheCreationInputTokens: 5,
+        webSearchRequests: 0,
+        costUSD: 0.01,
+        contextWindow: 200000,
+      };
+
+      expect(usage.inputTokens).toBe(100);
+      expect(usage.outputTokens).toBe(50);
+      expect(usage.costUSD).toBe(0.01);
+    });
+  });
+
+  describe('Beta types', () => {
+    it('should support context-1m beta', () => {
+      const beta: SdkBeta = 'context-1m-2025-08-07';
+      expect(beta).toBe('context-1m-2025-08-07');
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./tests",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["tests/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      include: ['node_modules/@anthropic-ai/claude-agent-sdk/**/*.js'],
+    },
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Problem

`handleControlRequest()` is launched fire-and-forget (not awaited) inside the `readMessages()` loop. In single-turn mode, when the `result` message arrives, `endInput()` is called immediately — closing `processStdin`. Any in-flight control handler that was awaiting async work (e.g. `canUseTool`, a hook callback) then resumes and calls `transport.write()` on the now-ended stream.

**Three-step failure cascade:**

1. `processStdin.write()` throws `ERR_STREAM_WRITE_AFTER_END` (Node < 23) or silently fails (Node 23+).
2. The `catch` block in `handleControlRequest` attempts a second `write()` (the error response), which also throws — now as an **unhandled rejection** because `handleControlRequest` was never awaited.
3. Node.js crashes.

The existing `!this.ready` / `!this.processStdin` guards don't help: `endInput()` leaves both fields set.

## Fix (3 lines in `ProcessTransport`)

```typescript
// 1. New class field:
private stdinEnded: boolean = false;

// 2. endInput() — set flag BEFORE calling .end():
endInput(): void {
  this.stdinEnded = true;          // concurrent writes see this immediately
  if (this.processStdin) this.processStdin.end();
}

// 3. write() — add as the VERY FIRST guard (before !this.ready check):
write(data: string): void {
  if (this.stdinEnded) return;     // silent drop — never throws
  // ... rest unchanged ...
}
```

**Why silent drop is safe:** after `endInput()` the subprocess has already emitted its `result` message and closed its stdin read loop. Any control response written at that point would be ignored by the subprocess regardless.

**Why `ready = false` in `endInput()` is NOT enough:** it changes the error string but the catch block still fires and its second `write()` becomes the unhandled rejection.

## Regression Test

`tests/process-transport-write-after-end.test.ts` reproduces the exact race:

- Mocks `spawnClaudeCodeProcess` with a controllable `PassThrough` process
- Sends a `control_request` followed immediately by a `result` message
- `canUseTool` introduces a 60 ms delay so `endInput()` fires before the handler finishes
- Listens for `unhandledRejection` events
- Asserts zero `ERR_STREAM_WRITE_AFTER_END` / `"write after end"` / `"ProcessTransport is not ready"` errors

The test **fails against the current SDK** (confirming the bug) and will pass once the fix is applied.

A second test confirms that `PassThrough.end()` sets `writableEnded` synchronously — the invariant the fix relies on.

## Checklist

- [x] Root cause identified in `ProcessTransport.write()` / `endInput()`
- [x] Fix is minimal (3 lines), backward-compatible, and safe
- [x] Regression test demonstrates the bug and will verify the fix
- [x] Second- and third-order effects verified (`finally` cleanup in `handleControlRequest`, `cleanup()` rejects pending MCP responses — no hangs)
- [x] `WebSocketTransport.endInput()` is a no-op and is unaffected

Closes #148