### PR TITLE
Read issue number from workflow event in edit-issue-labels.sh

### DIFF
--- a/.claude/commands/label-issue.md
+++ b/.claude/commands/label-issue.md
@@ -45,7 +45,7 @@ TASK OVERVIEW:
    - If you find similar issues using ./scripts/gh.sh search, consider using a "duplicate" label if appropriate. Only do so if the issue is a duplicate of another OPEN issue.
 
 5. Apply the selected labels:
-   - Use `./scripts/edit-issue-labels.sh --issue NUMBER --add-label LABEL1 --add-label LABEL2` to apply your selected labels
+   - Use `./scripts/edit-issue-labels.sh --add-label LABEL1 --add-label LABEL2` to apply your selected labels (issue number is read from the workflow event)
    - DO NOT post any comments explaining your decision
    - DO NOT communicate directly with users
    - If no labels are clearly applicable, do not apply any labels

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Run Claude Code for Issue Triage
         uses: anthropics/claude-code-action@main
+        env:
+          CLAUDE_CODE_SCRIPT_CAPS: '{"edit-issue-labels.sh":2}'
         with:
           prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/scripts/edit-issue-labels.sh
+++ b/scripts/edit-issue-labels.sh
@@ -1,22 +1,26 @@
 #!/usr/bin/env bash
 #
 # Edits labels on a GitHub issue.
-# Usage: ./scripts/edit-issue-labels.sh --issue 123 --add-label bug --add-label needs-triage --remove-label untriaged
+# Usage: ./scripts/edit-issue-labels.sh --add-label bug --add-label needs-triage --remove-label untriaged
+#
+# The issue number is read from the workflow event payload.
 #
 
 set -euo pipefail
 
-ISSUE=""
+# Read from event payload so the issue number is bound to the triggering event
+ISSUE=$(jq -r '.issue.number // empty' "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH not set}")
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "Error: no issue number in event payload" >&2
+  exit 1
+fi
+
 ADD_LABELS=()
 REMOVE_LABELS=()
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --issue)
-      ISSUE="$2"
-      shift 2
-      ;;
     --add-label)
       ADD_LABELS+=("$2")
       shift 2
@@ -26,19 +30,11 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     *)
+      echo "Error: unknown argument (only --add-label and --remove-label are accepted)" >&2
       exit 1
       ;;
   esac
 done
-
-# Validate issue number
-if [[ -z "$ISSUE" ]]; then
-  exit 1
-fi
-
-if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
-  exit 1
-fi
 
 if [[ ${#ADD_LABELS[@]} -eq 0 && ${#REMOVE_LABELS[@]} -eq 0 ]]; then
   exit 1


### PR DESCRIPTION
Updates `edit-issue-labels.sh` to read the issue number from `$GITHUB_EVENT_PATH` instead of a CLI argument. Simplifies the call signature and keeps the script aligned with the triggering issue.

<!-- NO CHANGELOG -->