### PR TITLE
examples: S3, Redis, Postgres SessionStore reference adapters

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.tgz
+.env
+.env.*
+bun.lock
+package-lock.json

--- a/examples/session-stores/README.md
+++ b/examples/session-stores/README.md
@@ -1,0 +1,303 @@
+# SessionStore reference adapters
+
+> **Reference implementations. Not published to npm, not maintained as production code.**
+
+Reference [`SessionStore`](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk)
+implementations for S3, Redis, and Postgres — copy the directory you need into
+your project, install the backend client, and wire it into
+`query({ options: { sessionStore } })`.
+
+These adapters live under `examples/` so the SDK package stays free of
+heavyweight optional dependencies. They are not part of the published
+`@anthropic-ai/claude-agent-sdk` package and are not built or tested by this
+repository's CI. Each adapter passes the 13-contract conformance suite in
+[`shared/conformance.ts`](shared/conformance.ts).
+
+| Adapter | Backend client | Unit tests | Live tests |
+| --- | --- | --- | --- |
+| [`s3/`](s3/) | `@aws-sdk/client-s3` | in-process mock | env-gated (`SESSION_STORE_S3_*`) |
+| [`redis/`](redis/) | `ioredis` | in-process mock | env-gated (`SESSION_STORE_REDIS_URL`) |
+| [`postgres/`](postgres/) | `pg` | constructor only | env-gated (`SESSION_STORE_POSTGRES_URL`) |
+
+## Layout
+
+Each adapter is a self-contained package:
+
+```
+{s3,redis,postgres}/
+  src/{Backend}SessionStore.ts   # the adapter — copy this into your project
+  src/index.ts
+  test/                          # unit + env-gated live conformance
+  demo.ts                        # runnable query() + resume round-trip
+  package.json
+  tsconfig.json
+shared/
+  conformance.ts                 # 13-contract behavioral suite
+```
+
+## Running an example
+
+```bash
+cd examples/session-stores/redis
+npm install                # or: bun install
+npm test                   # mock-backed unit tests, no Redis needed
+
+# live conformance (requires a real backend)
+docker run -d -p 6379:6379 redis:7-alpine
+SESSION_STORE_REDIS_URL=redis://localhost:6379/0 npm run test:live
+
+# end-to-end demo against the SDK (requires ANTHROPIC_API_KEY)
+SESSION_STORE_REDIS_URL=redis://localhost:6379/0 npm run demo
+```
+
+The S3 and Postgres directories follow the same pattern — see each `demo.ts`
+header for the corresponding `docker run` and env vars.
+
+## Validating your own adapter
+
+When you copy an adapter into your project (or write a new one), assert it
+satisfies the protocol's behavioral contracts with the vendored conformance
+harness:
+
+```typescript
+import { describe } from 'bun:test'
+import { runSessionStoreConformance } from './conformance.ts'
+
+describe('MyStore', () => {
+  runSessionStoreConformance(async () => new MyStore(/* fresh isolated state */))
+})
+```
+
+The factory must return a fresh, isolated store on every call (e.g. unique
+table name, key prefix, or bucket prefix).
+
+## Production checklist
+
+These adapters are reference code. Before running one in production, work
+through the relevant items below.
+
+### All adapters
+
+- The conformance suite proves *correctness*, not *resilience* — load-test
+  your adapter under your expected throughput.
+- `append()` failures are logged and surfaced as a stream error message; they
+  never block the conversation. Monitor for these so silent mirror gaps don't
+  go unnoticed.
+- The SDK never deletes from your store unless you call `deleteSession()` with
+  `delete()` implemented. Retention is your responsibility — implement TTL,
+  lifecycle policies, or scheduled cleanup according to your compliance
+  requirements.
+- Local-disk transcripts under `CLAUDE_CONFIG_DIR` are swept independently by
+  the CLI's `cleanupPeriodDays` setting.
+
+### S3
+
+- Required IAM actions on the bucket/prefix: `s3:PutObject`, `s3:GetObject`,
+  `s3:ListBucket`, `s3:DeleteObject`.
+- Part-file ordering uses the **client-side wall clock**. Multiple writer
+  instances with clock skew >1s may produce out-of-order `load()` results. Use
+  NTP or a single writer per session.
+- Consider S3 lifecycle policies for retention.
+- For sessions with >1000 part files, `load()` paginates correctly but latency
+  grows linearly; consider periodic compaction.
+
+### Redis
+
+- Set `maxmemory-policy noeviction` (or use a dedicated DB) — eviction will
+  silently drop session data.
+- Lists are unbounded; implement TTL via `EXPIRE` in a subclass if needed.
+- Redis Cluster: keys with the same `{projectKey}:{sessionId}` prefix should
+  hash to the same slot — wrap in `{...}` hash tags if using Cluster.
+
+### Postgres
+
+- Size the `pg.Pool` for expected concurrent sessions; don't share a pool
+  with request-handler code that holds connections.
+- `jsonb` reorders object keys — contract-safe (the SDK never byte-compares
+  entries), but don't byte-compare yourself.
+- Add a retention job (`DELETE WHERE created_at < ...`) — the table grows
+  unbounded.
+
+---
+
+## S3 — `s3/src/S3SessionStore.ts`
+
+Stores transcripts as JSONL part files:
+
+```
+s3://{bucket}/{prefix}{projectKey}/{sessionId}/part-{epochMs13}-{rand6}.jsonl
+```
+
+Each `append()` writes a new part; `load()` lists, sorts, and concatenates
+them.
+
+```typescript
+import { S3Client } from '@aws-sdk/client-s3'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { S3SessionStore } from './S3SessionStore.js'
+
+const store = new S3SessionStore({
+  bucket: 'my-claude-sessions',
+  prefix: 'transcripts',
+  client: new S3Client({ region: 'us-east-1' }),
+})
+
+for await (const message of query({
+  prompt: 'Hello!',
+  options: { sessionStore: store },
+})) {
+  if (message.type === 'result' && message.subtype === 'success') {
+    console.log(message.result)
+  }
+}
+```
+
+### Live S3 end-to-end
+
+```bash
+docker run -d -p 9000:9000 minio/minio server /data
+docker run --rm --network host minio/mc \
+  sh -c 'mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/test'
+
+cd examples/session-stores/s3
+npm install
+SESSION_STORE_S3_ENDPOINT=http://localhost:9000 \
+SESSION_STORE_S3_BUCKET=test \
+SESSION_STORE_S3_ACCESS_KEY=minioadmin \
+SESSION_STORE_S3_SECRET_KEY=minioadmin \
+  npm run test:live
+```
+
+---
+
+## Redis — `redis/src/RedisSessionStore.ts`
+
+Backed by [`ioredis`](https://github.com/redis/ioredis).
+
+```typescript
+import Redis from 'ioredis'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { RedisSessionStore } from './RedisSessionStore.js'
+
+const store = new RedisSessionStore({
+  client: new Redis({ host: 'localhost', port: 6379 }),
+  prefix: 'transcripts',
+})
+
+for await (const message of query({
+  prompt: 'Hello!',
+  options: { sessionStore: store },
+})) {
+  if (message.type === 'result' && message.subtype === 'success') {
+    console.log(message.result)
+  }
+}
+```
+
+### Key scheme
+
+```
+{prefix}:{projectKey}:{sessionId}             list   — main transcript entries (JSON each)
+{prefix}:{projectKey}:{sessionId}:{subpath}   list   — subagent transcript entries
+{prefix}:{projectKey}:{sessionId}:__subkeys   set    — subpaths under this session
+{prefix}:{projectKey}:__sessions              zset   — sessionId → mtime(ms)
+```
+
+Each `append()` is an `RPUSH` plus an index update in a single `MULTI`;
+`load()` is `LRANGE 0 -1`.
+
+### Live Redis end-to-end
+
+```bash
+docker run -d -p 6379:6379 redis:7-alpine
+cd examples/session-stores/redis
+npm install
+SESSION_STORE_REDIS_URL=redis://localhost:6379/0 npm run test:live
+```
+
+---
+
+## Postgres — `postgres/src/PostgresSessionStore.ts`
+
+Backed by [`pg`](https://node-postgres.com/).
+
+```typescript
+import { Pool } from 'pg'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { PostgresSessionStore } from './PostgresSessionStore.js'
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL })
+const store = new PostgresSessionStore({ pool })
+await store.ensureSchema() // idempotent CREATE TABLE IF NOT EXISTS
+
+for await (const message of query({
+  prompt: 'Hello!',
+  options: { sessionStore: store },
+})) {
+  if (message.type === 'result' && message.subtype === 'success') {
+    console.log(message.result)
+  }
+}
+```
+
+### Schema
+
+One row per transcript entry; `id` (a `BIGSERIAL`) orders entries within a
+`(project_key, session_id, subpath)` key:
+
+```sql
+CREATE TABLE claude_session_entries (
+  id          BIGSERIAL PRIMARY KEY,
+  project_key TEXT NOT NULL,
+  session_id  TEXT NOT NULL,
+  subpath     TEXT,               -- NULL = main transcript
+  entry       JSONB NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX claude_session_entries_key_idx
+  ON claude_session_entries (project_key, session_id, subpath, id);
+```
+
+`append()` is a single multi-row `INSERT`; `load()` is
+`SELECT entry ... ORDER BY id`.
+
+### JSONB key ordering
+
+Entries are stored as `jsonb`, which **reorders object keys** on read-back.
+This is explicitly allowed by the `SessionStore` contract — `load()` requires
+*deep-equal*, not *byte-equal*, returns. If you need byte-stable storage,
+switch the column to `json` (preserves text as-is) or `text`.
+
+### Live Postgres end-to-end
+
+There is no in-process Postgres mock comparable to `ioredis-mock`, so the
+Postgres conformance tests run **live-only**. They skip automatically unless
+`SESSION_STORE_POSTGRES_URL` is set:
+
+```bash
+docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine
+cd examples/session-stores/postgres
+npm install
+SESSION_STORE_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+  npm run test:live
+```
+
+Each run creates a random-suffixed table and `DROP`s it on teardown.
+
+---
+
+## Resume
+
+All three adapters support resume the same way:
+
+```typescript
+for await (const message of query({
+  prompt: 'Continue where we left off',
+  options: {
+    sessionStore: store,
+    resume: 'previous-session-id',
+  },
+})) {
+  // ...
+}
+```

--- a/examples/session-stores/postgres/demo.ts
+++ b/examples/session-stores/postgres/demo.ts
@@ -1,0 +1,45 @@
+/**
+ * End-to-end demo: run a query with PostgresSessionStore, then resume it.
+ *
+ * Prereqs:
+ *   - ANTHROPIC_API_KEY set
+ *   - Postgres reachable. For local testing:
+ *       docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine
+ *
+ * Run:
+ *   SESSION_STORE_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+ *     bun run demo.ts
+ */
+import { Pool } from 'pg'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { PostgresSessionStore } from './src/PostgresSessionStore.ts'
+
+const url = process.env.SESSION_STORE_POSTGRES_URL
+if (!url) {
+  console.error('Set SESSION_STORE_POSTGRES_URL (see header)')
+  process.exit(1)
+}
+
+const pool = new Pool({ connectionString: url })
+const store = new PostgresSessionStore({ pool })
+await store.ensureSchema()
+
+async function run(prompt: string, resume?: string) {
+  let sessionId: string | undefined
+  for await (const m of query({
+    prompt,
+    options: { sessionStore: store, resume, maxTurns: 1 },
+  })) {
+    if (m.type === 'system' && m.subtype === 'init') sessionId = m.session_id
+    if (m.type === 'result') {
+      console.log(`[${m.subtype}]`, 'result' in m ? m.result : '')
+    }
+  }
+  return sessionId
+}
+
+const sid = await run('Reply with exactly the word: pineapple')
+console.log('session', sid, 'mirrored to table claude_session_entries')
+
+await run('What single word did you just reply with?', sid)
+await pool.end()

--- a/examples/session-stores/postgres/package.json
+++ b/examples/session-stores/postgres/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "claude-agent-sdk-example-postgres-session-store",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Reference Postgres-backed SessionStore adapter for the Claude Agent SDK (example, not published)",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test test/PostgresSessionStore.test.ts",
+    "test:live": "bun test test/conformance.live.test.ts",
+    "demo": "bun run demo.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "latest",
+    "pg": "^8.13.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/pg": "^8.11.0",
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/examples/session-stores/postgres/src/PostgresSessionStore.ts
+++ b/examples/session-stores/postgres/src/PostgresSessionStore.ts
@@ -1,0 +1,122 @@
+import type { Pool } from 'pg'
+import type {
+  SessionKey,
+  SessionStore,
+  SessionStoreEntry,
+} from '@anthropic-ai/claude-agent-sdk'
+
+export type PostgresSessionStoreOptions = {
+  /** Pre-configured pg Pool. Caller controls connection params, pooling, TLS. */
+  pool: Pool
+  /** Table name. Must be a valid SQL identifier; default 'claude_session_entries'. */
+  tableName?: string
+}
+
+/**
+ * Postgres-backed SessionStore. One row per JSONL entry; ordering via BIGSERIAL.
+ * Reference implementation — proves the SessionStore contract maps to SQL.
+ */
+export class PostgresSessionStore implements SessionStore {
+  private readonly pool: Pool
+  private readonly table: string
+
+  constructor(opts: PostgresSessionStoreOptions) {
+    this.pool = opts.pool
+    const t = opts.tableName ?? 'claude_session_entries'
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(t)) {
+      throw new Error(`invalid tableName: ${t}`)
+    }
+    this.table = t
+  }
+
+  /** Creates the table + covering index if absent. Call once at startup. */
+  async ensureSchema(): Promise<void> {
+    await this.pool.query(`
+      CREATE TABLE IF NOT EXISTS ${this.table} (
+        id          BIGSERIAL PRIMARY KEY,
+        project_key TEXT NOT NULL,
+        session_id  TEXT NOT NULL,
+        subpath     TEXT,
+        entry       JSONB NOT NULL,
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `)
+    await this.pool.query(`
+      CREATE INDEX IF NOT EXISTS ${this.table}_key_idx
+        ON ${this.table} (project_key, session_id, subpath, id)
+    `)
+  }
+
+  async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
+    if (entries.length === 0) return
+    // Multi-row VALUES with parameterized placeholders: ($1,$2,$3,$4),($1,$2,$3,$5),...
+    // project_key/session_id/subpath are repeated; entry varies.
+    const params: unknown[] = [
+      key.projectKey,
+      key.sessionId,
+      key.subpath ?? null,
+    ]
+    const rows = entries.map((e, i) => {
+      params.push(JSON.stringify(e))
+      return `($1,$2,$3,$${4 + i}::jsonb)`
+    })
+    await this.pool.query(
+      `INSERT INTO ${this.table} (project_key, session_id, subpath, entry) VALUES ${rows.join(',')}`,
+      params,
+    )
+  }
+
+  async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
+    // IS NOT DISTINCT FROM matches NULL-to-NULL (subpath undefined → main transcript).
+    const { rows } = await this.pool.query<{ entry: SessionStoreEntry }>(
+      `SELECT entry FROM ${this.table}
+         WHERE project_key = $1 AND session_id = $2 AND subpath IS NOT DISTINCT FROM $3
+         ORDER BY id`,
+      [key.projectKey, key.sessionId, key.subpath ?? null],
+    )
+    return rows.length > 0 ? rows.map(r => r.entry) : null
+  }
+
+  async listSessions(
+    projectKey: string,
+  ): Promise<Array<{ sessionId: string; mtime: number }>> {
+    const { rows } = await this.pool.query<{ session_id: string; mtime: Date }>(
+      `SELECT session_id, MAX(created_at) AS mtime FROM ${this.table}
+         WHERE project_key = $1 AND subpath IS NULL
+         GROUP BY session_id
+         ORDER BY mtime DESC`,
+      [projectKey],
+    )
+    return rows.map(r => ({
+      sessionId: r.session_id,
+      mtime: r.mtime.getTime(),
+    }))
+  }
+
+  async delete(key: SessionKey): Promise<void> {
+    if (key.subpath === undefined) {
+      // Main-transcript delete cascades to all subpaths under (projectKey, sessionId).
+      await this.pool.query(
+        `DELETE FROM ${this.table} WHERE project_key = $1 AND session_id = $2`,
+        [key.projectKey, key.sessionId],
+      )
+    } else {
+      await this.pool.query(
+        `DELETE FROM ${this.table} WHERE project_key = $1 AND session_id = $2 AND subpath = $3`,
+        [key.projectKey, key.sessionId, key.subpath],
+      )
+    }
+  }
+
+  async listSubkeys(key: {
+    projectKey: string
+    sessionId: string
+  }): Promise<string[]> {
+    const { rows } = await this.pool.query<{ subpath: string }>(
+      `SELECT DISTINCT subpath FROM ${this.table}
+         WHERE project_key = $1 AND session_id = $2 AND subpath IS NOT NULL`,
+      [key.projectKey, key.sessionId],
+    )
+    return rows.map(r => r.subpath)
+  }
+}

--- a/examples/session-stores/postgres/src/index.ts
+++ b/examples/session-stores/postgres/src/index.ts
@@ -1,0 +1,2 @@
+export type { PostgresSessionStoreOptions } from './PostgresSessionStore.js'
+export { PostgresSessionStore } from './PostgresSessionStore.js'

--- a/examples/session-stores/postgres/test/PostgresSessionStore.test.ts
+++ b/examples/session-stores/postgres/test/PostgresSessionStore.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import type { Pool } from 'pg'
+import { PostgresSessionStore } from '../src/PostgresSessionStore.ts'
+
+describe('PostgresSessionStore (adapter-specific, no DB)', () => {
+  test('rejects invalid tableName', () => {
+    expect(
+      () =>
+        new PostgresSessionStore({
+          pool: {} as Pool,
+          tableName: 'a; DROP TABLE x',
+        }),
+    ).toThrow(/invalid tableName/)
+  })
+
+  test('accepts valid identifier', () => {
+    expect(
+      () =>
+        new PostgresSessionStore({
+          pool: {} as Pool,
+          tableName: 'my_sessions_v2',
+        }),
+    ).not.toThrow()
+  })
+})

--- a/examples/session-stores/postgres/test/conformance.live.test.ts
+++ b/examples/session-stores/postgres/test/conformance.live.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Live conformance suite against a real Postgres server.
+ * Skips automatically unless SESSION_STORE_POSTGRES_URL is set.
+ *
+ *   docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres postgres:16-alpine
+ *   SESSION_STORE_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgres \
+ *     bun test test/conformance.live.test.ts
+ */
+import { afterAll, describe, expect, test } from 'bun:test'
+import { Pool } from 'pg'
+import { PostgresSessionStore } from '../src/PostgresSessionStore.ts'
+import { runSessionStoreConformance } from '../../shared/conformance.ts'
+
+const url = process.env.SESSION_STORE_POSTGRES_URL
+
+describe.skipIf(!url)('PostgresSessionStore (live conformance)', () => {
+  const pool = new Pool({ connectionString: url })
+  const created: string[] = []
+
+  async function freshStore() {
+    const table = `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+    created.push(table)
+    const store = new PostgresSessionStore({ pool, tableName: table })
+    await store.ensureSchema()
+    return store
+  }
+
+  runSessionStoreConformance(freshStore)
+
+  test('ensureSchema is idempotent', async () => {
+    const store = await freshStore()
+    await store.ensureSchema()
+    await store.append({ projectKey: 'p', sessionId: 's' }, [{ type: 'a' }])
+    expect(await store.load({ projectKey: 'p', sessionId: 's' })).toEqual([
+      { type: 'a' },
+    ])
+  })
+
+  test('listSessions mtime is epoch ms', async () => {
+    const store = await freshStore()
+    const before = Date.now()
+    await store.append({ projectKey: 'p', sessionId: 's' }, [{ type: 'a' }])
+    const [s] = await store.listSessions('p')
+    expect(Math.abs(s!.mtime - before)).toBeLessThan(5000)
+  })
+
+  afterAll(async () => {
+    for (const t of created) {
+      await pool.query(`DROP TABLE IF EXISTS ${t}`)
+    }
+    await pool.end()
+  })
+})

--- a/examples/session-stores/postgres/tsconfig.json
+++ b/examples/session-stores/postgres/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "test", "demo.ts", "../shared/conformance.ts"]
+}

--- a/examples/session-stores/redis/demo.ts
+++ b/examples/session-stores/redis/demo.ts
@@ -1,0 +1,38 @@
+/**
+ * End-to-end demo: run a query with RedisSessionStore, then resume it.
+ *
+ * Prereqs:
+ *   - ANTHROPIC_API_KEY set
+ *   - Redis reachable. For local testing:
+ *       docker run -d -p 6379:6379 redis:7-alpine
+ *
+ * Run:
+ *   SESSION_STORE_REDIS_URL=redis://localhost:6379/0 bun run demo.ts
+ */
+import Redis from 'ioredis'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { RedisSessionStore } from './src/RedisSessionStore.ts'
+
+const url = process.env.SESSION_STORE_REDIS_URL ?? 'redis://localhost:6379/0'
+const client = new Redis(url)
+const store = new RedisSessionStore({ client, prefix: 'demo' })
+
+async function run(prompt: string, resume?: string) {
+  let sessionId: string | undefined
+  for await (const m of query({
+    prompt,
+    options: { sessionStore: store, resume, maxTurns: 1 },
+  })) {
+    if (m.type === 'system' && m.subtype === 'init') sessionId = m.session_id
+    if (m.type === 'result') {
+      console.log(`[${m.subtype}]`, 'result' in m ? m.result : '')
+    }
+  }
+  return sessionId
+}
+
+const sid = await run('Reply with exactly the word: pineapple')
+console.log('session', sid, 'mirrored to redis under prefix demo:')
+
+await run('What single word did you just reply with?', sid)
+await client.quit()

--- a/examples/session-stores/redis/package.json
+++ b/examples/session-stores/redis/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "claude-agent-sdk-example-redis-session-store",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Reference Redis-backed SessionStore adapter for the Claude Agent SDK (example, not published)",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test test/RedisSessionStore.test.ts",
+    "test:live": "bun test test/conformance.live.test.ts",
+    "demo": "bun run demo.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "latest",
+    "ioredis": "^5.4.1"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/examples/session-stores/redis/src/RedisSessionStore.ts
+++ b/examples/session-stores/redis/src/RedisSessionStore.ts
@@ -1,0 +1,139 @@
+import type { Redis } from 'ioredis'
+import type {
+  SessionKey,
+  SessionStore,
+  SessionStoreEntry,
+} from '@anthropic-ai/claude-agent-sdk'
+
+export type RedisSessionStoreOptions = {
+  /** Pre-configured ioredis client instance. Caller controls host, port, auth, etc. */
+  client: Redis
+  /** Optional key prefix (e.g., 'transcripts'). Trailing ':' is normalized. */
+  prefix?: string
+}
+
+/** Reserved subpath sentinel for the per-session subkey set. */
+const SUBKEYS = '__subkeys'
+/** Reserved sessionId sentinel for the per-project session index. */
+const SESSIONS = '__sessions'
+
+/**
+ * Redis-backed SessionStore.
+ *
+ * Key scheme (':' separator; projectKey/sessionId are opaque so collisions
+ * with the SDK's '/'-based projectKey are avoided):
+ *   {prefix}:{projectKey}:{sessionId}             → list (RPUSH/LRANGE) of JSON entries
+ *   {prefix}:{projectKey}:{sessionId}:{subpath}   → list of JSON entries
+ *   {prefix}:{projectKey}:{sessionId}:__subkeys   → set of subpaths under this session
+ *   {prefix}:{projectKey}:__sessions              → sorted set of sessionId, score=mtime(ms)
+ *
+ * Index keys (`__subkeys`, `__sessions`) live in reserved positions; the SDK
+ * never emits a sessionId of `__sessions` or a subpath of `__subkeys`.
+ *
+ * Retention: callers may set `EXPIRE` on the prefix via Redis-side policy or
+ * call `delete()`; this adapter never expires keys on its own.
+ */
+export class RedisSessionStore implements SessionStore {
+  private readonly client: Redis
+  private readonly prefix: string
+
+  constructor(options: RedisSessionStoreOptions) {
+    this.client = options.client
+    // Normalize: non-empty prefix always ends in exactly one ':'; empty stays empty.
+    this.prefix = options.prefix ? options.prefix.replace(/:+$/, '') + ':' : ''
+  }
+
+  /** Redis key for a transcript list (main or subpath). */
+  private entryKey(key: SessionKey): string {
+    const parts = [key.projectKey, key.sessionId]
+    if (key.subpath) parts.push(key.subpath)
+    return this.prefix + parts.join(':')
+  }
+
+  /** Redis key for the per-session subpath set. */
+  private subkeysKey(key: { projectKey: string; sessionId: string }): string {
+    return `${this.prefix}${key.projectKey}:${key.sessionId}:${SUBKEYS}`
+  }
+
+  /** Redis key for the per-project session index (sorted set, score=mtime). */
+  private sessionsKey(projectKey: string): string {
+    return `${this.prefix}${projectKey}:${SESSIONS}`
+  }
+
+  async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
+    if (entries.length === 0) return
+    const pipe = this.client.multi()
+    pipe.rpush(this.entryKey(key), ...entries.map(e => JSON.stringify(e)))
+    if (key.subpath) {
+      pipe.sadd(this.subkeysKey(key), key.subpath)
+    } else {
+      // Only main-transcript appends bump the session index — matches
+      // InMemorySessionStore.listSessions()'s "no subpath" filter and the S3
+      // adapter's main-parts-only mtime derivation.
+      pipe.zadd(this.sessionsKey(key.projectKey), Date.now(), key.sessionId)
+    }
+    await pipe.exec()
+  }
+
+  async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
+    const raw = await this.client.lrange(this.entryKey(key), 0, -1)
+    if (raw.length === 0) return null
+    const out: SessionStoreEntry[] = []
+    for (const line of raw) {
+      try {
+        out.push(JSON.parse(line))
+      } catch {
+        // Skip malformed entries (parity with S3SessionStore)
+      }
+    }
+    return out.length > 0 ? out : null
+  }
+
+  async listSessions(
+    projectKey: string,
+  ): Promise<Array<{ sessionId: string; mtime: number }>> {
+    const flat = await this.client.zrange(
+      this.sessionsKey(projectKey),
+      0,
+      -1,
+      'WITHSCORES',
+    )
+    const result: Array<{ sessionId: string; mtime: number }> = []
+    for (let i = 0; i < flat.length; i += 2) {
+      result.push({ sessionId: flat[i]!, mtime: Number(flat[i + 1]) })
+    }
+    return result
+  }
+
+  async delete(key: SessionKey): Promise<void> {
+    if (key.subpath !== undefined) {
+      // Targeted: remove just this subpath list and its index entry.
+      await this.client
+        .multi()
+        .del(this.entryKey(key))
+        .srem(this.subkeysKey(key), key.subpath)
+        .exec()
+      return
+    }
+    // Cascade: main list + every subpath list + subkey set + session-index entry.
+    const subkeysKey = this.subkeysKey(key)
+    const subpaths = await this.client.smembers(subkeysKey)
+    const toDelete = [
+      this.entryKey(key),
+      subkeysKey,
+      ...subpaths.map(sp => this.entryKey({ ...key, subpath: sp })),
+    ]
+    await this.client
+      .multi()
+      .del(...toDelete)
+      .zrem(this.sessionsKey(key.projectKey), key.sessionId)
+      .exec()
+  }
+
+  async listSubkeys(key: {
+    projectKey: string
+    sessionId: string
+  }): Promise<string[]> {
+    return this.client.smembers(this.subkeysKey(key))
+  }
+}

--- a/examples/session-stores/redis/src/index.ts
+++ b/examples/session-stores/redis/src/index.ts
@@ -1,0 +1,2 @@
+export type { RedisSessionStoreOptions } from './RedisSessionStore.js'
+export { RedisSessionStore } from './RedisSessionStore.js'

--- a/examples/session-stores/redis/test/RedisSessionStore.test.ts
+++ b/examples/session-stores/redis/test/RedisSessionStore.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from 'bun:test'
+import type { Redis } from 'ioredis'
+import { RedisSessionStore } from '../src/RedisSessionStore.ts'
+import { runSessionStoreConformance } from '../../shared/conformance.ts'
+
+/**
+ * Minimal in-process ioredis mock backing the subset of commands the adapter
+ * uses: rpush/lrange, sadd/srem/smembers, zadd/zrange/zrem, del, multi.
+ * `multi()` executes eagerly (no isolation needed for single-threaded tests).
+ */
+function makeMockRedis(): Redis {
+  const lists = new Map<string, string[]>()
+  const sets = new Map<string, Set<string>>()
+  const zsets = new Map<string, Map<string, number>>()
+
+  const api = {
+    async rpush(key: string, ...values: string[]) {
+      const l = lists.get(key) ?? []
+      l.push(...values)
+      lists.set(key, l)
+      return l.length
+    },
+    async lrange(key: string, start: number, stop: number) {
+      const l = lists.get(key) ?? []
+      const end = stop === -1 ? l.length : stop + 1
+      return l.slice(start, end)
+    },
+    async sadd(key: string, ...members: string[]) {
+      const s = sets.get(key) ?? new Set<string>()
+      let added = 0
+      for (const m of members) if (!s.has(m)) (s.add(m), added++)
+      sets.set(key, s)
+      return added
+    },
+    async srem(key: string, ...members: string[]) {
+      const s = sets.get(key)
+      if (!s) return 0
+      let removed = 0
+      for (const m of members) if (s.delete(m)) removed++
+      return removed
+    },
+    async smembers(key: string) {
+      return [...(sets.get(key) ?? [])]
+    },
+    async zadd(key: string, score: number, member: string) {
+      const z = zsets.get(key) ?? new Map<string, number>()
+      z.set(member, score)
+      zsets.set(key, z)
+      return 1
+    },
+    async zrange(
+      key: string,
+      start: number,
+      stop: number,
+      withScores?: 'WITHSCORES',
+    ) {
+      const z = zsets.get(key)
+      if (!z) return []
+      const sorted = [...z.entries()].sort((a, b) => a[1] - b[1])
+      const end = stop === -1 ? sorted.length : stop + 1
+      const slice = sorted.slice(start, end)
+      return withScores
+        ? slice.flatMap(([m, s]) => [m, String(s)])
+        : slice.map(([m]) => m)
+    },
+    async zrem(key: string, ...members: string[]) {
+      const z = zsets.get(key)
+      if (!z) return 0
+      let removed = 0
+      for (const m of members) if (z.delete(m)) removed++
+      return removed
+    },
+    async del(...keys: string[]) {
+      let n = 0
+      for (const k of keys) {
+        if (lists.delete(k)) n++
+        if (sets.delete(k)) n++
+        if (zsets.delete(k)) n++
+      }
+      return n
+    },
+    async keys(pattern: string) {
+      const all = new Set([...lists.keys(), ...sets.keys(), ...zsets.keys()])
+      if (pattern === '*') return [...all]
+      const re = new RegExp(
+        '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
+      )
+      return [...all].filter(k => re.test(k))
+    },
+    multi() {
+      const queue: Array<() => Promise<unknown>> = []
+      const chain: Record<string, unknown> = {
+        async exec() {
+          const out: Array<[null, unknown]> = []
+          for (const fn of queue) out.push([null, await fn()])
+          return out
+        },
+      }
+      for (const cmd of [
+        'rpush',
+        'sadd',
+        'srem',
+        'zadd',
+        'zrem',
+        'del',
+      ] as const) {
+        chain[cmd] = (...args: unknown[]) => {
+          queue.push(() =>
+            (api[cmd] as (...a: unknown[]) => Promise<unknown>)(...args),
+          )
+          return chain
+        }
+      }
+      return chain
+    },
+  }
+  return api as unknown as Redis
+}
+
+describe('RedisSessionStore (mock conformance)', () => {
+  let n = 0
+  runSessionStoreConformance(
+    () => new RedisSessionStore({ client: makeMockRedis(), prefix: `t${n++}` }),
+  )
+})
+
+describe('RedisSessionStore (adapter-specific)', () => {
+  const KEY = { projectKey: 'p', sessionId: 's' }
+
+  test('subpath append does not bump session index', async () => {
+    const client = makeMockRedis()
+    const store = new RedisSessionStore({ client, prefix: 't' })
+    await store.append({ ...KEY, subpath: 'subagents/a' }, [{ type: 'x' }])
+    expect(await store.listSessions('p')).toEqual([])
+    expect((await store.listSubkeys(KEY)).sort()).toEqual(['subagents/a'])
+  })
+
+  test('load skips malformed JSON', async () => {
+    const client = makeMockRedis()
+    await client.rpush('t:p:s', '{"type":"a"}', '{bad')
+    const store = new RedisSessionStore({ client, prefix: 't' })
+    expect(await store.load(KEY)).toEqual([{ type: 'a' }])
+  })
+
+  test.each(['', 'p', 'p:', 'p:::'])(
+    'prefix %j normalizes without :: artifacts',
+    async raw => {
+      const client = makeMockRedis()
+      const store = new RedisSessionStore({ client, prefix: raw })
+      await store.append(KEY, [{ type: 'a' }])
+      const keys = await client.keys('*')
+      for (const k of keys) {
+        expect(k.includes('::')).toBe(false)
+        expect(k.startsWith(':')).toBe(false)
+      }
+    },
+  )
+})

--- a/examples/session-stores/redis/test/conformance.live.test.ts
+++ b/examples/session-stores/redis/test/conformance.live.test.ts
@@ -1,0 +1,29 @@
+/**
+ * Live conformance suite against a real Redis server.
+ * Skips automatically unless SESSION_STORE_REDIS_URL is set.
+ *
+ *   docker run -d -p 6379:6379 redis:7-alpine
+ *   SESSION_STORE_REDIS_URL=redis://localhost:6379/0 bun test test/conformance.live.test.ts
+ */
+import { afterAll, describe } from 'bun:test'
+import Redis from 'ioredis'
+import { RedisSessionStore } from '../src/RedisSessionStore.ts'
+import { runSessionStoreConformance } from '../../shared/conformance.ts'
+
+const url = process.env.SESSION_STORE_REDIS_URL
+
+describe.skipIf(!url)('RedisSessionStore (live conformance)', () => {
+  const client = new Redis(url!, { lazyConnect: false })
+  const root = `conformance-${Date.now().toString(36)}`
+  let n = 0
+
+  runSessionStoreConformance(
+    () => new RedisSessionStore({ client, prefix: `${root}:${n++}` }),
+  )
+
+  afterAll(async () => {
+    const keys = await client.keys(`${root}:*`)
+    if (keys.length) await client.del(...keys)
+    await client.quit()
+  })
+})

--- a/examples/session-stores/redis/tsconfig.json
+++ b/examples/session-stores/redis/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "test", "demo.ts", "../shared/conformance.ts"]
+}

--- a/examples/session-stores/s3/demo.ts
+++ b/examples/session-stores/s3/demo.ts
@@ -1,0 +1,52 @@
+/**
+ * End-to-end demo: run a query with S3SessionStore, then resume it.
+ *
+ * Prereqs:
+ *   - ANTHROPIC_API_KEY set
+ *   - An S3-compatible endpoint. For local testing with MinIO:
+ *       docker run -d -p 9000:9000 minio/minio server /data
+ *       docker run --rm --network host minio/mc \
+ *         sh -c 'mc alias set local http://localhost:9000 minioadmin minioadmin && mc mb local/claude-sessions'
+ *
+ * Run:
+ *   SESSION_STORE_S3_ENDPOINT=http://localhost:9000 \
+ *   SESSION_STORE_S3_BUCKET=claude-sessions \
+ *   AWS_ACCESS_KEY_ID=minioadmin AWS_SECRET_ACCESS_KEY=minioadmin \
+ *     bun run demo.ts
+ */
+import { S3Client } from '@aws-sdk/client-s3'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { S3SessionStore } from './src/S3SessionStore.ts'
+
+const bucket = process.env.SESSION_STORE_S3_BUCKET
+if (!bucket) {
+  console.error('Set SESSION_STORE_S3_BUCKET (see header for MinIO setup)')
+  process.exit(1)
+}
+
+const client = new S3Client({
+  region: process.env.AWS_REGION ?? 'us-east-1',
+  endpoint: process.env.SESSION_STORE_S3_ENDPOINT,
+  forcePathStyle: !!process.env.SESSION_STORE_S3_ENDPOINT,
+})
+
+const store = new S3SessionStore({ bucket, prefix: 'demo', client })
+
+async function run(prompt: string, resume?: string) {
+  let sessionId: string | undefined
+  for await (const m of query({
+    prompt,
+    options: { sessionStore: store, resume, maxTurns: 1 },
+  })) {
+    if (m.type === 'system' && m.subtype === 'init') sessionId = m.session_id
+    if (m.type === 'result') {
+      console.log(`[${m.subtype}]`, 'result' in m ? m.result : '')
+    }
+  }
+  return sessionId
+}
+
+const sid = await run('Reply with exactly the word: pineapple')
+console.log('session', sid, 'mirrored to s3://' + bucket + '/demo/')
+
+await run('What single word did you just reply with?', sid)

--- a/examples/session-stores/s3/package.json
+++ b/examples/session-stores/s3/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "claude-agent-sdk-example-s3-session-store",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Reference S3-backed SessionStore adapter for the Claude Agent SDK (example, not published)",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test test/S3SessionStore.test.ts",
+    "test:live": "bun test test/conformance.live.test.ts",
+    "demo": "bun run demo.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "latest",
+    "@aws-sdk/client-s3": "^3.750.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/examples/session-stores/s3/src/S3SessionStore.ts
+++ b/examples/session-stores/s3/src/S3SessionStore.ts
@@ -1,0 +1,305 @@
+import {
+  DeleteObjectsCommand,
+  type DeleteObjectsCommandInput,
+  GetObjectCommand,
+  type GetObjectCommandInput,
+  ListObjectsV2Command,
+  type ListObjectsV2CommandInput,
+  PutObjectCommand,
+  type PutObjectCommandInput,
+  type S3Client,
+} from '@aws-sdk/client-s3'
+import type {
+  SessionKey,
+  SessionStore,
+  SessionStoreEntry,
+} from '@anthropic-ai/claude-agent-sdk'
+
+const LOAD_CONCURRENCY = 16
+
+export type S3SessionStoreOptions = {
+  /** S3 bucket name */
+  bucket: string
+  /** Optional key prefix (e.g., 'transcripts'). Trailing slash is normalized. */
+  prefix?: string
+  /** Pre-configured S3Client instance. Caller controls region, credentials, etc. */
+  client: S3Client
+}
+
+/**
+ * S3-backed SessionStore. append() = new part file `{prefix}{projectKey}/{sessionId}/part-{epochMs13}-{rand6}.jsonl`;
+ * load() = list+sort+concat. Monotonic ms orders same-instance same-ms appends; rand suffix disambiguates instances.
+ */
+export class S3SessionStore implements SessionStore {
+  private readonly bucket: string
+  private readonly prefix: string
+  private readonly client: S3Client
+  private lastMs = 0
+
+  constructor(options: S3SessionStoreOptions) {
+    this.bucket = options.bucket
+    // Normalize: non-empty prefix always ends in exactly one '/'; empty stays empty.
+    this.prefix = options.prefix ? options.prefix.replace(/\/+$/, '') + '/' : ''
+    this.client = options.client
+  }
+
+  /** Directory prefix for a session (or subpath). Always ends in '/'. */
+  private keyPrefix(key: SessionKey): string {
+    const parts = [key.projectKey, key.sessionId]
+    if (key.subpath) {
+      parts.push(key.subpath)
+    }
+    return this.prefix + parts.join('/') + '/'
+  }
+
+  /** Directory prefix for a project. Always ends in '/'. */
+  private projectPrefix(projectKey: string): string {
+    return this.prefix + projectKey + '/'
+  }
+
+  /**
+   * Fixed-width epoch ms → lexical sort = chronological. lastMs+1 makes
+   * same-instance same-ms appends deterministic; rand disambiguates instances.
+   */
+  private nextPartName(): string {
+    const now = Date.now()
+    const ms = Math.max(now, this.lastMs + 1)
+    this.lastMs = ms
+    const rand = Math.random().toString(16).slice(2, 8).padStart(6, '0')
+    return `part-${ms.toString().padStart(13, '0')}-${rand}.jsonl`
+  }
+
+  async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
+    if (entries.length === 0) {
+      return
+    }
+    const objectKey = this.keyPrefix(key) + this.nextPartName()
+    const body = entries.map(e => JSON.stringify(e)).join('\n') + '\n'
+
+    await this.client.send(
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: objectKey,
+        Body: body,
+        ContentType: 'application/x-ndjson',
+      } satisfies PutObjectCommandInput),
+    )
+  }
+
+  async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
+    const prefix = this.keyPrefix(key)
+    let continuationToken: string | undefined
+
+    // List part files directly under this prefix only. Without Delimiter,
+    // S3 recurses into subpaths (e.g. subagents/*), so a main-transcript
+    // load({projectKey, sessionId}) would mix in subagent entries — diverging
+    // from InMemorySessionStore's exact-key semantics and corrupting resume.
+    const keys: string[] = []
+    do {
+      const listResult = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          Delimiter: '/',
+          ContinuationToken: continuationToken,
+        } satisfies ListObjectsV2CommandInput),
+      )
+      if (listResult.Contents) {
+        for (const obj of listResult.Contents) {
+          // Guard against S3-compatibles that ignore Delimiter: keep only
+          // direct children (part files have no '/' after the prefix).
+          if (obj.Key && !obj.Key.slice(prefix.length).includes('/')) {
+            keys.push(obj.Key)
+          }
+        }
+      }
+      continuationToken = listResult.NextContinuationToken
+    } while (continuationToken)
+
+    if (keys.length === 0) {
+      return null
+    }
+
+    // Sort by key (lexicographic -- 13-digit epochMs prefix is fixed-width,
+    // so lexical order == chronological order)
+    keys.sort()
+
+    // Bounded-parallel GetObject (serial is N×RTT); preserves sorted-key order.
+    const allEntries: SessionStoreEntry[] = []
+    for (let i = 0; i < keys.length; i += LOAD_CONCURRENCY) {
+      const batch = keys.slice(i, i + LOAD_CONCURRENCY)
+      const bodies = await Promise.all(
+        batch.map(async objectKey => {
+          const getResult = await this.client.send(
+            new GetObjectCommand({
+              Bucket: this.bucket,
+              Key: objectKey,
+            } satisfies GetObjectCommandInput),
+          )
+          return getResult.Body?.transformToString()
+        }),
+      )
+      for (const body of bodies) {
+        if (!body) {
+          continue
+        }
+        for (const line of body.split('\n')) {
+          const trimmed = line.trim()
+          if (!trimmed) {
+            continue
+          }
+          try {
+            allEntries.push(JSON.parse(trimmed))
+          } catch {
+            // Skip malformed lines
+          }
+        }
+      }
+    }
+
+    return allEntries.length > 0 ? allEntries : null
+  }
+
+  async listSessions(
+    projectKey: string,
+  ): Promise<Array<{ sessionId: string; mtime: number }>> {
+    const prefix = this.projectPrefix(projectKey)
+    const sessions = new Map<string, number>()
+    let continuationToken: string | undefined
+
+    // List Contents (no Delimiter) so we can derive mtime from each part
+    // filename's 13-digit epochMs prefix. CommonPrefixes carry no timestamp.
+    do {
+      const result = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        }),
+      )
+      if (result.Contents) {
+        for (const obj of result.Contents) {
+          if (!obj.Key) {
+            continue
+          }
+          // {prefix}{sessionId}/part-{epochMs13}-{rand}.jsonl
+          const rest = obj.Key.slice(prefix.length)
+          const slash = rest.indexOf('/')
+          if (slash === -1) {
+            continue
+          }
+          // Main-transcript parts only (one level under sessionId); deeper keys
+          // are subagent parts and would surface phantom sessionIds / skew mtime.
+          if (rest.indexOf('/', slash + 1) !== -1) {
+            continue
+          }
+          const sessionId = rest.slice(0, slash)
+          const m = obj.Key.match(/\/part-(\d{13})-[0-9a-f]{6}\.jsonl$/)
+          const mtime = m ? Number(m[1]) : (obj.LastModified?.getTime() ?? 0)
+          const prev = sessions.get(sessionId) ?? 0
+          if (mtime > prev) {
+            sessions.set(sessionId, mtime)
+          }
+        }
+      }
+      continuationToken = result.NextContinuationToken
+    } while (continuationToken)
+
+    return Array.from(sessions, ([sessionId, mtime]) => ({
+      sessionId,
+      mtime,
+    }))
+  }
+
+  async delete(key: SessionKey): Promise<void> {
+    const prefix = this.keyPrefix(key)
+    // Match InMemorySessionStore: whole-session delete cascades into subpaths;
+    // delete({subpath:'a'}) is exact-key only (must NOT touch 'a/b').
+    const directOnly = key.subpath !== undefined
+    let continuationToken: string | undefined
+
+    do {
+      const listResult = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          Delimiter: directOnly ? '/' : undefined,
+          ContinuationToken: continuationToken,
+        }),
+      )
+      const toDelete: Array<{ Key: string }> = []
+      if (listResult.Contents) {
+        for (const obj of listResult.Contents) {
+          if (!obj.Key) {
+            continue
+          }
+          if (directOnly && obj.Key.slice(prefix.length).includes('/')) {
+            continue
+          }
+          toDelete.push({ Key: obj.Key })
+        }
+      }
+      if (toDelete.length > 0) {
+        const result = await this.client.send(
+          new DeleteObjectsCommand({
+            Bucket: this.bucket,
+            Delete: { Objects: toDelete, Quiet: true },
+          } satisfies DeleteObjectsCommandInput),
+        )
+        if (result.Errors?.length) {
+          throw new Error(
+            `S3 delete failed for ${result.Errors.length} object(s): ${result.Errors.map(e => `${e.Key}: ${e.Code}`).join(', ')}`,
+          )
+        }
+      }
+      continuationToken = listResult.NextContinuationToken
+    } while (continuationToken)
+  }
+
+  async listSubkeys(key: {
+    projectKey: string
+    sessionId: string
+  }): Promise<string[]> {
+    const prefix = this.keyPrefix({
+      projectKey: key.projectKey,
+      sessionId: key.sessionId,
+    })
+    const subkeys = new Set<string>()
+    let continuationToken: string | undefined
+
+    do {
+      const result = await this.client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        }),
+      )
+      if (result.Contents) {
+        for (const obj of result.Contents) {
+          if (obj.Key) {
+            // Extract subpath from key:
+            // {prefix}{projectKey}/{sessionId}/{subpath}/part-{epochMs}-{rand}.jsonl
+            const rel = obj.Key.slice(prefix.length)
+            const parts = rel.split('/')
+            if (parts.length >= 2) {
+              // subpath is everything except the last segment (the part file)
+              const subpath = parts.slice(0, -1).join('/')
+              if (subpath) {
+                subkeys.add(subpath)
+              }
+            }
+          }
+        }
+      }
+      continuationToken = result.NextContinuationToken
+    } while (continuationToken)
+
+    // Defense-in-depth: drop '..'/'.'/'' segments (never produced by legit
+    // writers). Primary traversal guard stays in materializeResumeSession.
+    return Array.from(subkeys).filter(
+      sp =>
+        !sp.split('/').some(seg => seg === '..' || seg === '.' || seg === ''),
+    )
+  }
+}

--- a/examples/session-stores/s3/src/index.ts
+++ b/examples/session-stores/s3/src/index.ts
@@ -1,0 +1,2 @@
+export type { S3SessionStoreOptions } from './S3SessionStore.js'
+export { S3SessionStore } from './S3SessionStore.js'

--- a/examples/session-stores/s3/test/S3SessionStore.test.ts
+++ b/examples/session-stores/s3/test/S3SessionStore.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from 'bun:test'
+import type { S3Client } from '@aws-sdk/client-s3'
+import { S3SessionStore } from '../src/S3SessionStore.ts'
+import { runSessionStoreConformance } from '../../shared/conformance.ts'
+
+/**
+ * Minimal in-process S3Client mock backed by a Map<Key, Body>.
+ * Honors Prefix and Delimiter:'/' for ListObjectsV2.
+ */
+function makeMockClient() {
+  const objects = new Map<string, string>()
+  const calls: Array<{ name: string; input: Record<string, unknown> }> = []
+
+  const client = {
+    async send(cmd: {
+      constructor: { name: string }
+      input: Record<string, unknown>
+    }) {
+      const name = cmd.constructor.name
+      const input = cmd.input
+      calls.push({ name, input })
+      switch (name) {
+        case 'PutObjectCommand': {
+          objects.set(input.Key as string, input.Body as string)
+          return {}
+        }
+        case 'GetObjectCommand': {
+          const body = objects.get(input.Key as string)
+          return { Body: { transformToString: async () => body } }
+        }
+        case 'ListObjectsV2Command': {
+          const prefix = (input.Prefix as string) ?? ''
+          const delimiter = input.Delimiter as string | undefined
+          const matched = [...objects.keys()].filter(k => k.startsWith(prefix))
+          const contents = matched
+            .filter(
+              k => !delimiter || !k.slice(prefix.length).includes(delimiter),
+            )
+            .map(Key => ({ Key }))
+          return { Contents: contents }
+        }
+        case 'DeleteObjectsCommand': {
+          for (const o of (input.Delete as { Objects: Array<{ Key: string }> })
+            .Objects) {
+            objects.delete(o.Key)
+          }
+          return {}
+        }
+        default:
+          throw new Error(`unhandled ${name}`)
+      }
+    },
+  } as unknown as S3Client
+  return { client, objects, calls }
+}
+
+describe('S3SessionStore (mock conformance)', () => {
+  let n = 0
+  runSessionStoreConformance(() => {
+    const { client } = makeMockClient()
+    return new S3SessionStore({ bucket: 'b', prefix: `t${n++}`, client })
+  })
+})
+
+describe('S3SessionStore (adapter-specific)', () => {
+  const KEY = { projectKey: 'p', sessionId: 's' }
+
+  test('append writes part-{epochMs13}-{rand6}.jsonl under prefix', async () => {
+    const { client, objects } = makeMockClient()
+    const store = new S3SessionStore({ bucket: 'b', prefix: 't', client })
+    await store.append(KEY, [{ type: 'a' }])
+    const [k] = [...objects.keys()]
+    expect(k).toMatch(/^t\/p\/s\/part-\d{13}-[0-9a-f]{6}\.jsonl$/)
+  })
+
+  test('same-ms appends are lexically ordered (monotonic counter)', async () => {
+    const { client, objects } = makeMockClient()
+    const store = new S3SessionStore({ bucket: 'b', client })
+    const original = Date.now
+    Date.now = () => 1700000000000
+    try {
+      await store.append(KEY, [{ type: 'a' }])
+      await store.append(KEY, [{ type: 'b' }])
+      await store.append(KEY, [{ type: 'c' }])
+    } finally {
+      Date.now = original
+    }
+    const ks = [...objects.keys()].sort()
+    expect(ks).toEqual([...objects.keys()])
+    const loaded = await store.load(KEY)
+    expect(loaded?.map(e => e.type)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('append([]) issues no PutObject', async () => {
+    const { client, calls } = makeMockClient()
+    const store = new S3SessionStore({ bucket: 'b', client })
+    await store.append(KEY, [])
+    expect(calls.filter(c => c.name === 'PutObjectCommand')).toHaveLength(0)
+  })
+
+  test('load skips malformed JSON lines', async () => {
+    const { client, objects } = makeMockClient()
+    objects.set('p/s/part-0000000000001-000000.jsonl', '{"type":"a"}\n{bad\n')
+    const store = new S3SessionStore({ bucket: 'b', client })
+    expect(await store.load(KEY)).toEqual([{ type: 'a' }])
+  })
+
+  test('listSubkeys filters traversal segments', async () => {
+    const { client, objects } = makeMockClient()
+    objects.set('p/s/subagents/a/part-0000000000001-000000.jsonl', '{}')
+    objects.set('p/s/../evil/part-0000000000001-000000.jsonl', '{}')
+    const store = new S3SessionStore({ bucket: 'b', client })
+    expect(await store.listSubkeys(KEY)).toEqual(['subagents/a'])
+  })
+
+  test.each(['', 'p', 'p/', 'p///'])(
+    'prefix %j normalizes without // artifacts',
+    async raw => {
+      const { client, objects } = makeMockClient()
+      const store = new S3SessionStore({ bucket: 'b', prefix: raw, client })
+      await store.append(KEY, [{ type: 'a' }])
+      const [k] = [...objects.keys()]
+      expect(k.includes('//')).toBe(false)
+      expect(k.startsWith('/')).toBe(raw === '' ? false : false)
+    },
+  )
+})

--- a/examples/session-stores/s3/test/conformance.live.test.ts
+++ b/examples/session-stores/s3/test/conformance.live.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Live conformance suite against a real S3-compatible endpoint.
+ * Skips automatically unless SESSION_STORE_S3_ENDPOINT and
+ * SESSION_STORE_S3_BUCKET are set. See ../demo.ts for MinIO setup.
+ */
+import { afterAll, describe } from 'bun:test'
+import { S3Client } from '@aws-sdk/client-s3'
+import { S3SessionStore } from '../src/S3SessionStore.ts'
+import { runSessionStoreConformance } from '../../shared/conformance.ts'
+
+const endpoint = process.env.SESSION_STORE_S3_ENDPOINT
+const bucket = process.env.SESSION_STORE_S3_BUCKET
+const accessKeyId = process.env.SESSION_STORE_S3_ACCESS_KEY
+const secretAccessKey = process.env.SESSION_STORE_S3_SECRET_KEY
+
+const enabled = !!(endpoint && bucket)
+
+describe.skipIf(!enabled)('S3SessionStore (live conformance)', () => {
+  const client = new S3Client({
+    region: process.env.AWS_REGION ?? 'us-east-1',
+    endpoint,
+    forcePathStyle: true,
+    credentials:
+      accessKeyId && secretAccessKey
+        ? { accessKeyId, secretAccessKey }
+        : undefined,
+  })
+  const root = `conformance-${Date.now().toString(36)}`
+  let n = 0
+
+  runSessionStoreConformance(
+    () =>
+      new S3SessionStore({
+        bucket: bucket!,
+        prefix: `${root}/${n++}`,
+        client,
+      }),
+  )
+
+  afterAll(async () => {
+    // Best-effort cleanup of everything written under the root prefix.
+    const { ListObjectsV2Command, DeleteObjectsCommand } = await import(
+      '@aws-sdk/client-s3'
+    )
+    let token: string | undefined
+    do {
+      const r = await client.send(
+        new ListObjectsV2Command({
+          Bucket: bucket!,
+          Prefix: root + '/',
+          ContinuationToken: token,
+        }),
+      )
+      const objs = (r.Contents ?? [])
+        .map(o => o.Key)
+        .filter((k): k is string => !!k)
+      if (objs.length) {
+        await client.send(
+          new DeleteObjectsCommand({
+            Bucket: bucket!,
+            Delete: { Objects: objs.map(Key => ({ Key })), Quiet: true },
+          }),
+        )
+      }
+      token = r.NextContinuationToken
+    } while (token)
+  })
+})

--- a/examples/session-stores/s3/tsconfig.json
+++ b/examples/session-stores/s3/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "test", "demo.ts", "../shared/conformance.ts"]
+}

--- a/examples/session-stores/shared/conformance.ts
+++ b/examples/session-stores/shared/conformance.ts
@@ -1,0 +1,213 @@
+/**
+ * SessionStore behavioral conformance suite.
+ *
+ * Any adapter that passes these 13 checks satisfies the contract the SDK
+ * relies on for transcript mirroring and resume. The suite is vendored here
+ * (rather than imported from the SDK) so the example adapters can be tested
+ * standalone without depending on unpublished SDK internals.
+ *
+ * Usage with bun:test:
+ *
+ *   import { describe } from 'bun:test'
+ *   import { runSessionStoreConformance } from '../../shared/conformance.ts'
+ *
+ *   describe('MyStore', () => {
+ *     runSessionStoreConformance(async () => new MyStore(...))
+ *   })
+ */
+import { test, expect } from 'bun:test'
+
+// Structural copies of the SDK's SessionStore types so this file has zero
+// install-time dependencies. The adapters under test import the real types
+// from `@anthropic-ai/claude-agent-sdk`; structural typing makes them
+// assignable here.
+type SessionKey = { projectKey: string; sessionId: string; subpath?: string }
+type SessionStoreEntry = { type: string; [k: string]: unknown }
+type SessionStore = {
+  append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void>
+  load(key: SessionKey): Promise<SessionStoreEntry[] | null>
+  listSessions?(
+    projectKey: string,
+  ): Promise<Array<{ sessionId: string; mtime: number }>>
+  delete?(key: SessionKey): Promise<void>
+  listSubkeys?(key: {
+    projectKey: string
+    sessionId: string
+  }): Promise<string[]>
+}
+
+export type ConformanceFactory = () => Promise<SessionStore> | SessionStore
+
+const KEY: SessionKey = { projectKey: 'proj', sessionId: 'sess' }
+
+const E = (type: string, extra: Record<string, unknown> = {}) =>
+  ({ type, ...extra }) as SessionStoreEntry
+
+/** Sorted-key stringify so deep-equal ignores object-key order (JSONB-safe). */
+function canon(v: unknown): string {
+  return JSON.stringify(v, (_k, val) =>
+    val && typeof val === 'object' && !Array.isArray(val)
+      ? Object.fromEntries(
+          Object.entries(val as Record<string, unknown>).sort(([a], [b]) =>
+            a < b ? -1 : a > b ? 1 : 0,
+          ),
+        )
+      : val,
+  )
+}
+
+function expectEntries(actual: unknown, expected: SessionStoreEntry[]) {
+  expect(canon(actual)).toBe(canon(expected))
+}
+
+/**
+ * Registers 13 `bun:test` cases against the given factory. Call inside a
+ * `describe()` block. The factory must return a fresh, isolated store on
+ * every call (e.g. unique table name / key prefix).
+ */
+export function runSessionStoreConformance(makeStore: ConformanceFactory) {
+  test('append then load returns same entries in same order', async () => {
+    const store = await makeStore()
+    const entries = [E('a', { n: 1, nested: { x: [1, 2] } }), E('b', { n: 2 })]
+    await store.append(KEY, entries)
+    expectEntries(await store.load(KEY), entries)
+  })
+
+  test('load unknown key returns null', async () => {
+    const store = await makeStore()
+    expect(await store.load(KEY)).toBeNull()
+    expect(await store.load({ ...KEY, subpath: 'subagents/a' })).toBeNull()
+  })
+
+  test('multiple append calls preserve call order', async () => {
+    const store = await makeStore()
+    await store.append(KEY, [E('a')])
+    await store.append(KEY, [E('b'), E('c')])
+    await store.append(KEY, [E('d')])
+    expectEntries(await store.load(KEY), [E('a'), E('b'), E('c'), E('d')])
+  })
+
+  test('append([]) is a no-op', async () => {
+    const store = await makeStore()
+    await store.append(KEY, [])
+    expect(await store.load(KEY)).toBeNull()
+    await store.append(KEY, [E('a')])
+    await store.append(KEY, [])
+    expectEntries(await store.load(KEY), [E('a')])
+  })
+
+  test('subpath keys are stored independently of main', async () => {
+    const store = await makeStore()
+    await store.append(KEY, [E('main')])
+    await store.append({ ...KEY, subpath: 'subagents/x' }, [E('sub')])
+    expectEntries(await store.load(KEY), [E('main')])
+    expectEntries(await store.load({ ...KEY, subpath: 'subagents/x' }), [
+      E('sub'),
+    ])
+  })
+
+  test('projectKey isolation', async () => {
+    const store = await makeStore()
+    const A = { projectKey: 'A', sessionId: 's' }
+    const B = { projectKey: 'B', sessionId: 's' }
+    await store.append(A, [E('a')])
+    await store.append(B, [E('b')])
+    expectEntries(await store.load(A), [E('a')])
+    expectEntries(await store.load(B), [E('b')])
+  })
+
+  test('listSessions returns sessionIds for project', async () => {
+    const store = await makeStore()
+    if (!store.listSessions) return
+    await store.append({ projectKey: 'P', sessionId: 's1' }, [E('a')])
+    await store.append({ projectKey: 'P', sessionId: 's2' }, [E('b')])
+    await store.append({ projectKey: 'Q', sessionId: 's3' }, [E('c')])
+    const ids = (await store.listSessions('P')).map(s => s.sessionId).sort()
+    expect(ids).toEqual(['s1', 's2'])
+    const r = await store.listSessions('P')
+    expect(r.every(s => s.mtime > 1e12)).toBe(true)
+    expect(await store.listSessions('never-seen')).toEqual([])
+  })
+
+  test('listSessions excludes subagent subpaths', async () => {
+    const store = await makeStore()
+    if (!store.listSessions) return
+    await store.append(
+      { projectKey: 'P', sessionId: 's1', subpath: 'subagents/x' },
+      [E('sub')],
+    )
+    const ids = (await store.listSessions('P')).map(s => s.sessionId)
+    expect(ids).not.toContain('s1')
+  })
+
+  test('delete main then load returns null', async () => {
+    const store = await makeStore()
+    if (!store.delete) return
+    await store.append(KEY, [E('a')])
+    await store.delete(KEY)
+    expect(await store.load(KEY)).toBeNull()
+    await store.delete({ projectKey: 'x', sessionId: 'never' })
+  })
+
+  test('delete main cascades to subkeys', async () => {
+    const store = await makeStore()
+    if (!store.delete) return
+    await store.append(KEY, [E('main')])
+    await store.append({ ...KEY, subpath: 'subagents/a' }, [E('sa')])
+    await store.append({ ...KEY, subpath: 'subagents/b' }, [E('sb')])
+    await store.append({ projectKey: 'proj', sessionId: 'other' }, [E('o')])
+    await store.append({ projectKey: 'proj2', sessionId: 'sess' }, [E('p2')])
+    await store.delete(KEY)
+    expect(await store.load(KEY)).toBeNull()
+    expect(await store.load({ ...KEY, subpath: 'subagents/a' })).toBeNull()
+    expect(await store.load({ ...KEY, subpath: 'subagents/b' })).toBeNull()
+    expectEntries(
+      await store.load({ projectKey: 'proj', sessionId: 'other' }),
+      [E('o')],
+    )
+    expectEntries(
+      await store.load({ projectKey: 'proj2', sessionId: 'sess' }),
+      [E('p2')],
+    )
+    if (store.listSubkeys) {
+      expect(await store.listSubkeys(KEY)).toEqual([])
+    }
+  })
+
+  test('delete with subpath removes only that subkey', async () => {
+    const store = await makeStore()
+    if (!store.delete) return
+    await store.append(KEY, [E('main')])
+    await store.append({ ...KEY, subpath: 'subagents/a' }, [E('sa')])
+    await store.append({ ...KEY, subpath: 'subagents/b' }, [E('sb')])
+    await store.delete({ ...KEY, subpath: 'subagents/a' })
+    expectEntries(await store.load(KEY), [E('main')])
+    expect(await store.load({ ...KEY, subpath: 'subagents/a' })).toBeNull()
+    expectEntries(await store.load({ ...KEY, subpath: 'subagents/b' }), [
+      E('sb'),
+    ])
+  })
+
+  test('listSubkeys returns subpaths for the session', async () => {
+    const store = await makeStore()
+    if (!store.listSubkeys) return
+    await store.append({ ...KEY, subpath: 'subagents/a' }, [E('sa')])
+    await store.append({ ...KEY, subpath: 'subagents/b' }, [E('sb')])
+    await store.append(
+      { projectKey: 'proj', sessionId: 'other', subpath: 'subagents/c' },
+      [E('sc')],
+    )
+    const subs = (await store.listSubkeys(KEY)).sort()
+    expect(subs).toEqual(['subagents/a', 'subagents/b'])
+  })
+
+  test('listSubkeys excludes main transcript', async () => {
+    const store = await makeStore()
+    if (!store.listSubkeys) return
+    await store.append(KEY, [E('main')])
+    expect(await store.listSubkeys(KEY)).toEqual([])
+    expect(
+      await store.listSubkeys({ projectKey: 'x', sessionId: 'never' }),
+    ).toEqual([])
+  })
+}


### PR DESCRIPTION
Three self-contained reference `SessionStore` implementations under `examples/session-stores/`, each importing types from the published `@anthropic-ai/claude-agent-sdk` package.

| Adapter | Backend client | Unit tests | Live tests |
| --- | --- | --- | --- |
| `s3/` | `@aws-sdk/client-s3` | in-process mock | env-gated `SESSION_STORE_S3_*` |
| `redis/` | `ioredis` | in-process mock | env-gated `SESSION_STORE_REDIS_URL` |
| `postgres/` | `pg` | constructor only | env-gated `SESSION_STORE_POSTGRES_URL` |

Each adapter directory is independently runnable:

```bash
cd examples/session-stores/redis
npm install
npm test                                                    # mock conformance
SESSION_STORE_REDIS_URL=redis://localhost:6379/0 npm run test:live   # real Redis
SESSION_STORE_REDIS_URL=redis://localhost:6379/0 npm run demo        # query() + resume
```

`shared/conformance.ts` vendors the 13-contract behavioral suite so users can validate custom adapters.

**CI / packaging impact: none.** Nothing under `examples/` is packaged or published; `examples/.gitignore` excludes `node_modules` and lockfiles; no workflow is added; the only existing PR-triggered workflow is path-filtered to `.github/**`.

**Verified locally:**
- `bun run typecheck` clean in all three (fresh-clone simulation, each installed independently)
- Mock unit tests: s3 22✓, redis 19✓, postgres 2✓; live suites skip when env unset
- Live conformance against dockerized `redis:7-alpine`, `postgres:16-alpine`, MinIO: 13/13 each
- Staged diff scanned for internal references — clean