### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/slack-issue-notification.yml
+++ b/.github/workflows/slack-issue-notification.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Post to Slack
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # 2.1.1
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1 (sha-pinned)
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
Pin third-party GitHub Actions references to immutable commit SHAs.