### PR TITLE
examples: add Synap memory integration example

### DIFF
--- a/examples/synap-memory.ts
+++ b/examples/synap-memory.ts
@@ -1,0 +1,69 @@
+/**
+ * Example: Synap memory integration.
+ *
+ * Demonstrates how to give a Claude Agent persistent, cross-session memory
+ * using Synap (https://maximem.ai) — a managed memory layer for AI agents.
+ *
+ * Two plug points:
+ *   1. `createSynapHooks` — UserPromptSubmit hook that fetches relevant Synap
+ *      context for each prompt and injects it via `additionalContext`.
+ *      Optionally records the user prompt for future recall.
+ *   2. `createSynapMcpServer` — exposes `synap_search` and `synap_remember`
+ *      as MCP tools the model can call explicitly.
+ *
+ * Install:
+ *   npm install @maximem/synap-claude-agent @anthropic-ai/claude-agent-sdk zod
+ *
+ * Set SYNAP_API_KEY in your environment. Get a free key at
+ * https://synap.maximem.ai.
+ *
+ * Open source: https://github.com/maximem-ai/maximem_synap_sdk
+ */
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { MaximemSynapSDK } from "@maximem/synap-sdk";
+import {
+  createSynapHooks,
+  createSynapMcpServer,
+} from "@maximem/synap-claude-agent";
+
+async function main(): Promise<void> {
+  const sdk = new MaximemSynapSDK({ apiKey: process.env.SYNAP_API_KEY! });
+  await sdk.initialize();
+
+  const userId = "demo-user-001";
+  const customerId = "demo-customer";
+
+  // Pattern 1 — automatic context injection via hook
+  console.log("=== Hook-based context injection ===");
+  for await (const message of query({
+    prompt: "What did I tell you about my dietary preferences?",
+    options: {
+      hooks: createSynapHooks({ sdk, userId, customerId }),
+    },
+  })) {
+    console.log(message);
+  }
+
+  // Pattern 2 — explicit search / remember via MCP tools
+  console.log("\n=== MCP tool-based memory access ===");
+  for await (const message of query({
+    prompt: "Remember that I prefer concise answers, then search my memory.",
+    options: {
+      mcpServers: {
+        synap: createSynapMcpServer({ sdk, userId, customerId }),
+      },
+      allowedTools: [
+        "mcp__synap__synap_search",
+        "mcp__synap__synap_remember",
+      ],
+    },
+  })) {
+    console.log(message);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/examples/synap-memory.ts
+++ b/examples/synap-memory.ts
@@ -5,65 +5,71 @@
  * using Synap (https://maximem.ai) — a managed memory layer for AI agents.
  *
  * Two plug points:
- *   1. `createSynapHooks` — UserPromptSubmit hook that fetches relevant Synap
- *      context for each prompt and injects it via `additionalContext`.
+ *   1. createSynapHooks — UserPromptSubmit hook that fetches relevant Synap
+ *      context for each prompt and injects it via additionalContext.
  *      Optionally records the user prompt for future recall.
- *   2. `createSynapMcpServer` — exposes `synap_search` and `synap_remember`
+ *   2. createSynapMcpServer — exposes synap_search and synap_remember
  *      as MCP tools the model can call explicitly.
+ *
+ * Prereqs:
+ *   - ANTHROPIC_API_KEY set
+ *   - SYNAP_API_KEY set (free key at https://synap.maximem.ai)
  *
  * Install:
  *   npm install @maximem/synap-claude-agent @anthropic-ai/claude-agent-sdk zod
  *
- * Set SYNAP_API_KEY in your environment. Get a free key at
- * https://synap.maximem.ai.
+ * Run:
+ *   bun run synap-memory.ts
  *
  * Open source: https://github.com/maximem-ai/maximem_synap_sdk
  */
-
-import { query } from "@anthropic-ai/claude-agent-sdk";
-import { MaximemSynapSDK } from "@maximem/synap-sdk";
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { MaximemSynapSDK } from '@maximem/synap-sdk'
 import {
   createSynapHooks,
   createSynapMcpServer,
-} from "@maximem/synap-claude-agent";
+} from '@maximem/synap-claude-agent'
 
-async function main(): Promise<void> {
-  const sdk = new MaximemSynapSDK({ apiKey: process.env.SYNAP_API_KEY! });
-  await sdk.initialize();
-
-  const userId = "demo-user-001";
-  const customerId = "demo-customer";
-
-  // Pattern 1 — automatic context injection via hook
-  console.log("=== Hook-based context injection ===");
-  for await (const message of query({
-    prompt: "What did I tell you about my dietary preferences?",
-    options: {
-      hooks: createSynapHooks({ sdk, userId, customerId }),
-    },
-  })) {
-    console.log(message);
-  }
-
-  // Pattern 2 — explicit search / remember via MCP tools
-  console.log("\n=== MCP tool-based memory access ===");
-  for await (const message of query({
-    prompt: "Remember that I prefer concise answers, then search my memory.",
-    options: {
-      mcpServers: {
-        synap: createSynapMcpServer({ sdk, userId, customerId }),
-      },
-      allowedTools: [
-        "mcp__synap__synap_search",
-        "mcp__synap__synap_remember",
-      ],
-    },
-  })) {
-    console.log(message);
-  }
+const synapKey = process.env.SYNAP_API_KEY
+if (!synapKey) {
+  console.error('Set SYNAP_API_KEY (free key at https://synap.maximem.ai)')
+  process.exit(1)
+}
+if (!process.env.ANTHROPIC_API_KEY) {
+  console.error('Set ANTHROPIC_API_KEY')
+  process.exit(1)
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+const sdk = new MaximemSynapSDK({ apiKey: synapKey })
+await sdk.initialize()
+
+const userId = 'demo-user-001'
+const customerId = 'demo-customer'
+
+// Pattern 1 — automatic context injection via hook
+console.log('=== Hook-based context injection ===')
+for await (const message of query({
+  prompt: 'What did I tell you about my dietary preferences?',
+  options: {
+    hooks: createSynapHooks({ sdk, userId, customerId }),
+  },
+})) {
+  console.log(message)
+}
+
+// Pattern 2 — explicit search / remember via MCP tools
+console.log('\n=== MCP tool-based memory access ===')
+for await (const message of query({
+  prompt: 'Remember that I prefer concise answers, then search my memory.',
+  options: {
+    mcpServers: {
+      synap: createSynapMcpServer({ sdk, userId, customerId }),
+    },
+    allowedTools: [
+      'mcp__synap__synap_search',
+      'mcp__synap__synap_remember',
+    ],
+  },
+})) {
+  console.log(message)
+}


### PR DESCRIPTION
## Summary

Adds `examples/synap-memory.ts` showing how to give a Claude Agent persistent, cross-session memory via [Synap](https://maximem.ai), using both plug points:

- `createSynapHooks` — UserPromptSubmit hook that fetches Synap context and injects it via `additionalContext`
- `createSynapMcpServer` — exposes `synap_search` / `synap_remember` as MCP tools the model can call explicitly

The package is published on npm as `@maximem/synap-claude-agent`. Source code lives in our open source repo: https://github.com/maximem-ai/maximem_synap_sdk/tree/main/packages/integrations/synap-claude-agent-ts

Paired with the Python sibling PR: anthropics/claude-agent-sdk-python#954

## Test plan

- [x] Manually ran the example with `SYNAP_API_KEY` set
- [x] Verified hook injection adds Synap context
- [x] Verified MCP tools `synap_search` / `synap_remember` are callable