### PR TITLE
Use workload identity federation for Claude auth in issue triage

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -11,6 +11,9 @@ jobs:
     permissions:
       contents: read
       issues: write
+      # Required to mint the OIDC token that is exchanged for a Claude API
+      # access token (Workload Identity Federation).
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -24,6 +27,12 @@ jobs:
           CLAUDE_CODE_SCRIPT_CAPS: '{"edit-issue-labels.sh":2}'
         with:
           prompt: "/label-issue REPO: ${{ github.repository }} ISSUE_NUMBER: ${{ github.event.issue.number }}"
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate to the Claude API via Workload Identity Federation
+          # (the workflow's OIDC token is exchanged for a short-lived access
+          # token) instead of a static API key.
+          anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
+          anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
+          anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
+          anthropic_workspace_id: ${{ vars.ANTHROPIC_WORKSPACE_ID }}
           allowed_non_write_users: "*" # Required for issue triage workflow, if users without repo write access create issues
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Switches the issue triage workflow from the static `ANTHROPIC_API_KEY` secret to [Workload Identity Federation](https://platform.claude.com/docs/en/manage-claude/workload-identity-federation): the workflow's GitHub OIDC token is exchanged for a short-lived Claude API access token at runtime, so no long-lived API key needs to be stored in the repository.

`issue-triage.yml` is the only workflow in this repository that uses `secrets.ANTHROPIC_API_KEY`. The change replaces the `anthropic_api_key` input with the federation inputs and adds `id-token: write` to the job's permissions so the workflow can mint an OIDC token.

This is the same feature [`claude-code-action`](https://github.com/anthropics/claude-code-action) ships for its users (anthropics/claude-code-action#1338, [`docs/setup.md`](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md)).

## How it activates

The federation rule, organization, and service account IDs are read from repository **variables** (`vars.ANTHROPIC_FEDERATION_RULE_ID`, `vars.ANTHROPIC_ORGANIZATION_ID`, `vars.ANTHROPIC_SERVICE_ACCOUNT_ID`). These are identifiers, not credentials. Until a repo admin sets them, the action fails fast at env validation with a clear "authentication required" message — so this PR is safe to merge ahead of that, and switching over is a settings change rather than another PR.

The `ANTHROPIC_API_KEY` secret is intentionally left in place until the federated path has produced green runs; rollback is reverting this PR.
