### PR TITLE
examples: MongoDB SessionStore reference adapter

### DIFF
--- a/examples/session-stores/README.md
+++ b/examples/session-stores/README.md
@@ -3,8 +3,8 @@
 > **Reference implementations. Not published to npm, not maintained as production code.**
 
 Reference [`SessionStore`](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk)
-implementations for S3, Redis, and Postgres — copy the directory you need into
-your project, install the backend client, and wire it into
+implementations for S3, Redis, Postgres, and MongoDB — copy the directory you
+need into your project, install the backend client, and wire it into
 `query({ options: { sessionStore } })`.
 
 These adapters live under `examples/` so the SDK package stays free of
@@ -18,13 +18,14 @@ repository's CI. Each adapter passes the 13-contract conformance suite in
 | [`s3/`](s3/) | `@aws-sdk/client-s3` | in-process mock | env-gated (`SESSION_STORE_S3_*`) |
 | [`redis/`](redis/) | `ioredis` | in-process mock | env-gated (`SESSION_STORE_REDIS_URL`) |
 | [`postgres/`](postgres/) | `pg` | constructor only | env-gated (`SESSION_STORE_POSTGRES_URL`) |
+| [`mongodb/`](mongodb/) | `mongodb` | constructor only | env-gated (`SESSION_STORE_MONGODB_URL`) |
 
 ## Layout
 
 Each adapter is a self-contained package:
 
 ```
-{s3,redis,postgres}/
+{s3,redis,postgres,mongodb}/
   src/{Backend}SessionStore.ts   # the adapter — copy this into your project
   src/index.ts
   test/                          # unit + env-gated live conformance
@@ -50,8 +51,8 @@ SESSION_STORE_REDIS_URL=redis://localhost:6379/0 npm run test:live
 SESSION_STORE_REDIS_URL=redis://localhost:6379/0 npm run demo
 ```
 
-The S3 and Postgres directories follow the same pattern — see each `demo.ts`
-header for the corresponding `docker run` and env vars.
+The S3, Postgres, and MongoDB directories follow the same pattern — see each
+`demo.ts` header for the corresponding `docker run` and env vars.
 
 ## Validating your own adapter
 
@@ -117,6 +118,16 @@ through the relevant items below.
   entries), but don't byte-compare yourself.
 - Add a retention job (`DELETE WHERE created_at < ...`) — the table grows
   unbounded.
+
+### MongoDB
+
+- Size the `MongoClient` pool for expected concurrent sessions; don't share a
+  pool with request-handler code that holds connections.
+- Use a write concern of at least `w: 1` (the driver default). If you tune to
+  `w: 0`, mirror writes are fire-and-forget and a server crash can lose
+  recently-appended entries — the conformance suite assumes durability.
+- Implement retention via a TTL index on `createdAt` or a scheduled
+  `deleteMany` — the collection grows unbounded.
 
 ---
 
@@ -283,6 +294,70 @@ SESSION_STORE_POSTGRES_URL=postgresql://postgres:postgres@localhost:5432/postgre
 ```
 
 Each run creates a random-suffixed table and `DROP`s it on teardown.
+
+---
+
+## MongoDB — `mongodb/src/MongoDBSessionStore.ts`
+
+Backed by the official [`mongodb`](https://www.mongodb.com/docs/drivers/node/)
+Node driver.
+
+```typescript
+import { MongoClient } from 'mongodb'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { MongoDBSessionStore } from './MongoDBSessionStore.js'
+
+const client = new MongoClient(process.env.MONGODB_URL!)
+await client.connect()
+const store = new MongoDBSessionStore({ client, dbName: 'claude' })
+await store.ensureSchema() // idempotent createIndexes
+
+for await (const message of query({
+  prompt: 'Hello!',
+  options: { sessionStore: store },
+})) {
+  if (message.type === 'result' && message.subtype === 'success') {
+    console.log(message.result)
+  }
+}
+```
+
+### Schema
+
+One document per transcript entry; the server-generated `_id` (an `ObjectId`)
+orders entries within a `(projectKey, sessionId, subpath)` key:
+
+```ts
+{
+  _id: ObjectId,
+  projectKey: string,
+  sessionId: string,
+  subpath: string | null,   // null = main transcript
+  entry: SessionStoreEntry, // opaque JSON
+  createdAt: Date,
+}
+```
+
+`ensureSchema()` creates two indexes — one covering `(projectKey, sessionId,
+subpath, _id)` for `load()`/`delete()`/`listSubkeys()`, and one covering
+`(projectKey, subpath, createdAt)` for `listSessions()`. `append()` is a
+single `insertMany`; `load()` is `find().sort({ _id: 1 })`.
+
+### Live MongoDB end-to-end
+
+There is no in-process MongoDB mock that faithfully exercises the aggregation
+pipeline and `distinct`, so the MongoDB conformance tests run **live-only**.
+They skip automatically unless `SESSION_STORE_MONGODB_URL` is set:
+
+```bash
+docker run -d -p 27017:27017 mongo:7
+cd examples/session-stores/mongodb
+npm install
+SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 \
+  npm run test:live
+```
+
+Each run creates a random-suffixed collection and drops it on teardown.
 
 ---
 

--- a/examples/session-stores/README.md
+++ b/examples/session-stores/README.md
@@ -123,9 +123,6 @@ through the relevant items below.
 
 - Size the `MongoClient` pool for expected concurrent sessions; don't share a
   pool with request-handler code that holds connections.
-- Use a write concern of at least `w: 1` (the driver default). If you tune to
-  `w: 0`, mirror writes are fire-and-forget and a server crash can lose
-  recently-appended entries — the conformance suite assumes durability.
 - Implement retention via a TTL index on `createdAt` or a scheduled
   `deleteMany` — the collection grows unbounded.
 

--- a/examples/session-stores/README.md
+++ b/examples/session-stores/README.md
@@ -350,7 +350,7 @@ pipeline and `distinct`, so the MongoDB conformance tests run **live-only**.
 They skip automatically unless `SESSION_STORE_MONGODB_URL` is set:
 
 ```bash
-docker run -d -p 27017:27017 mongo:7
+docker run -d -p 27017:27017 mongo:latest
 cd examples/session-stores/mongodb
 npm install
 SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 \

--- a/examples/session-stores/mongodb/demo.ts
+++ b/examples/session-stores/mongodb/demo.ts
@@ -4,7 +4,7 @@
  * Prereqs:
  *   - ANTHROPIC_API_KEY set
  *   - MongoDB reachable. For local testing:
- *       docker run -d -p 27017:27017 mongo:7
+ *       docker run -d -p 27017:27017 mongo:latest
  *
  * Run:
  *   SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 \

--- a/examples/session-stores/mongodb/demo.ts
+++ b/examples/session-stores/mongodb/demo.ts
@@ -1,0 +1,47 @@
+/**
+ * End-to-end demo: run a query with MongoDBSessionStore, then resume it.
+ *
+ * Prereqs:
+ *   - ANTHROPIC_API_KEY set
+ *   - MongoDB reachable. For local testing:
+ *       docker run -d -p 27017:27017 mongo:7
+ *
+ * Run:
+ *   SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 \
+ *     bun run demo.ts
+ */
+import { MongoClient } from 'mongodb'
+import { query } from '@anthropic-ai/claude-agent-sdk'
+import { MongoDBSessionStore } from './src/MongoDBSessionStore.ts'
+
+const url = process.env.SESSION_STORE_MONGODB_URL
+if (!url) {
+  console.error('Set SESSION_STORE_MONGODB_URL (see header)')
+  process.exit(1)
+}
+
+const dbName = process.env.SESSION_STORE_MONGODB_DB ?? 'claude_test'
+const client = new MongoClient(url)
+await client.connect()
+const store = new MongoDBSessionStore({ client, dbName })
+await store.ensureSchema()
+
+async function run(prompt: string, resume?: string) {
+  let sessionId: string | undefined
+  for await (const m of query({
+    prompt,
+    options: { sessionStore: store, resume, maxTurns: 1 },
+  })) {
+    if (m.type === 'system' && m.subtype === 'init') sessionId = m.session_id
+    if (m.type === 'result') {
+      console.log(`[${m.subtype}]`, 'result' in m ? m.result : '')
+    }
+  }
+  return sessionId
+}
+
+const sid = await run('Reply with exactly the word: pineapple')
+console.log('session', sid, `mirrored to ${dbName}.claude_session_entries`)
+
+await run('What single word did you just reply with?', sid)
+await client.close()

--- a/examples/session-stores/mongodb/package.json
+++ b/examples/session-stores/mongodb/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "claude-agent-sdk-example-mongodb-session-store",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Reference MongoDB-backed SessionStore adapter for the Claude Agent SDK (example, not published)",
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test test/MongoDBSessionStore.test.ts",
+    "test:live": "bun test test/conformance.live.test.ts",
+    "demo": "bun run demo.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "latest",
+    "mongodb": "^6.10.0"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  },
+  "license": "MIT"
+}

--- a/examples/session-stores/mongodb/src/MongoDBSessionStore.ts
+++ b/examples/session-stores/mongodb/src/MongoDBSessionStore.ts
@@ -1,0 +1,128 @@
+import type { Collection, MongoClient } from 'mongodb'
+import type {
+  SessionKey,
+  SessionStore,
+  SessionStoreEntry,
+} from '@anthropic-ai/claude-agent-sdk'
+
+export type MongoDBSessionStoreOptions = {
+  /** Pre-configured MongoClient. Caller controls auth, TLS, pooling. */
+  client: MongoClient
+  /** Database name. Falls back to the client's default database when omitted. */
+  dbName?: string
+  /** Collection name. Must match /^[A-Za-z_][A-Za-z0-9_.]*$/; default 'claude_session_entries'. */
+  collectionName?: string
+}
+
+type EntryDoc = {
+  projectKey: string
+  sessionId: string
+  subpath: string | null
+  entry: SessionStoreEntry
+  createdAt: Date
+}
+
+/**
+ * MongoDB-backed SessionStore. One document per JSONL entry; ordering via
+ * server-generated ObjectId (`_id`). Reference implementation — proves the
+ * SessionStore contract maps to a document store.
+ */
+export class MongoDBSessionStore implements SessionStore {
+  private readonly client: MongoClient
+  private readonly dbName: string | undefined
+  private readonly collectionName: string
+
+  constructor(opts: MongoDBSessionStoreOptions) {
+    this.client = opts.client
+    this.dbName = opts.dbName
+    const c = opts.collectionName ?? 'claude_session_entries'
+    if (!/^[A-Za-z_][A-Za-z0-9_.]*$/.test(c)) {
+      throw new Error(`invalid collectionName: ${c}`)
+    }
+    this.collectionName = c
+  }
+
+  private collection(): Collection<EntryDoc> {
+    return this.client.db(this.dbName).collection<EntryDoc>(this.collectionName)
+  }
+
+  /** Creates the indexes if absent. Call once at startup. */
+  async ensureSchema(): Promise<void> {
+    await this.collection().createIndexes([
+      {
+        key: { projectKey: 1, sessionId: 1, subpath: 1, _id: 1 },
+        name: 'key_idx',
+      },
+      {
+        key: { projectKey: 1, subpath: 1, createdAt: -1 },
+        name: 'sessions_idx',
+      },
+    ])
+  }
+
+  async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
+    if (entries.length === 0) return
+    const now = new Date()
+    const docs: EntryDoc[] = entries.map(entry => ({
+      projectKey: key.projectKey,
+      sessionId: key.sessionId,
+      subpath: key.subpath ?? null,
+      entry,
+      createdAt: now,
+    }))
+    await this.collection().insertMany(docs, { ordered: true })
+  }
+
+  async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
+    const docs = await this.collection()
+      .find({
+        projectKey: key.projectKey,
+        sessionId: key.sessionId,
+        subpath: key.subpath ?? null,
+      })
+      .sort({ _id: 1 })
+      .toArray()
+    return docs.length > 0 ? docs.map(d => d.entry) : null
+  }
+
+  async listSessions(
+    projectKey: string,
+  ): Promise<Array<{ sessionId: string; mtime: number }>> {
+    const rows = await this.collection()
+      .aggregate<{ _id: string; mtime: Date }>([
+        { $match: { projectKey, subpath: null } },
+        { $group: { _id: '$sessionId', mtime: { $max: '$createdAt' } } },
+        { $sort: { mtime: -1 } },
+      ])
+      .toArray()
+    return rows.map(r => ({ sessionId: r._id, mtime: r.mtime.getTime() }))
+  }
+
+  async delete(key: SessionKey): Promise<void> {
+    if (key.subpath === undefined) {
+      // Main-transcript delete cascades to all subpaths under (projectKey, sessionId).
+      await this.collection().deleteMany({
+        projectKey: key.projectKey,
+        sessionId: key.sessionId,
+      })
+    } else {
+      await this.collection().deleteMany({
+        projectKey: key.projectKey,
+        sessionId: key.sessionId,
+        subpath: key.subpath,
+      })
+    }
+  }
+
+  async listSubkeys(key: {
+    projectKey: string
+    sessionId: string
+  }): Promise<string[]> {
+    const subs = await this.collection().distinct('subpath', {
+      projectKey: key.projectKey,
+      sessionId: key.sessionId,
+      subpath: { $ne: null },
+    })
+    return subs.filter((s): s is string => typeof s === 'string')
+  }
+}

--- a/examples/session-stores/mongodb/src/index.ts
+++ b/examples/session-stores/mongodb/src/index.ts
@@ -1,0 +1,2 @@
+export type { MongoDBSessionStoreOptions } from './MongoDBSessionStore.js'
+export { MongoDBSessionStore } from './MongoDBSessionStore.js'

--- a/examples/session-stores/mongodb/test/MongoDBSessionStore.test.ts
+++ b/examples/session-stores/mongodb/test/MongoDBSessionStore.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test'
+import type { MongoClient } from 'mongodb'
+import { MongoDBSessionStore } from '../src/MongoDBSessionStore.ts'
+
+describe('MongoDBSessionStore (adapter-specific, no DB)', () => {
+  test('rejects invalid collectionName', () => {
+    expect(
+      () =>
+        new MongoDBSessionStore({
+          client: {} as MongoClient,
+          collectionName: 'a; drop',
+        }),
+    ).toThrow(/invalid collectionName/)
+  })
+
+  test('accepts valid identifier', () => {
+    expect(
+      () =>
+        new MongoDBSessionStore({
+          client: {} as MongoClient,
+          collectionName: 'my_sessions_v2',
+        }),
+    ).not.toThrow()
+  })
+})

--- a/examples/session-stores/mongodb/test/conformance.live.test.ts
+++ b/examples/session-stores/mongodb/test/conformance.live.test.ts
@@ -2,7 +2,7 @@
  * Live conformance suite against a real MongoDB server.
  * Skips automatically unless SESSION_STORE_MONGODB_URL is set.
  *
- *   docker run -d -p 27017:27017 mongo:7
+ *   docker run -d -p 27017:27017 mongo:latest
  *   SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 \
  *     bun test test/conformance.live.test.ts
  */

--- a/examples/session-stores/mongodb/test/conformance.live.test.ts
+++ b/examples/session-stores/mongodb/test/conformance.live.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Live conformance suite against a real MongoDB server.
+ * Skips automatically unless SESSION_STORE_MONGODB_URL is set.
+ *
+ *   docker run -d -p 27017:27017 mongo:7
+ *   SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 \
+ *     bun test test/conformance.live.test.ts
+ */
+import { afterAll, describe, expect, test } from 'bun:test'
+import { MongoClient } from 'mongodb'
+import { MongoDBSessionStore } from '../src/MongoDBSessionStore.ts'
+import { runSessionStoreConformance } from '../../shared/conformance.ts'
+
+const url = process.env.SESSION_STORE_MONGODB_URL
+const dbName = process.env.SESSION_STORE_MONGODB_DB ?? 'claude_test'
+
+describe.skipIf(!url)('MongoDBSessionStore (live conformance)', () => {
+  // Guard so the constructor does not run when the suite is skipped.
+  const client = url ? new MongoClient(url) : (null as unknown as MongoClient)
+  const created: string[] = []
+
+  async function freshStore() {
+    const collectionName = `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`
+    created.push(collectionName)
+    const store = new MongoDBSessionStore({ client, dbName, collectionName })
+    await store.ensureSchema()
+    return store
+  }
+
+  runSessionStoreConformance(freshStore)
+
+  test('ensureSchema is idempotent', async () => {
+    const store = await freshStore()
+    await store.ensureSchema()
+    await store.append({ projectKey: 'p', sessionId: 's' }, [{ type: 'a' }])
+    expect(await store.load({ projectKey: 'p', sessionId: 's' })).toEqual([
+      { type: 'a' },
+    ])
+  })
+
+  test('listSessions mtime is epoch ms', async () => {
+    const store = await freshStore()
+    const before = Date.now()
+    await store.append({ projectKey: 'p', sessionId: 's' }, [{ type: 'a' }])
+    const [s] = await store.listSessions('p')
+    expect(Math.abs(s!.mtime - before)).toBeLessThan(5000)
+  })
+
+  afterAll(async () => {
+    const db = client.db(dbName)
+    for (const c of created) {
+      await db.collection(c).drop().catch(() => undefined)
+    }
+    await client.close()
+  })
+})

--- a/examples/session-stores/mongodb/tsconfig.json
+++ b/examples/session-stores/mongodb/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src", "test", "demo.ts", "../shared/conformance.ts"]
+}


### PR DESCRIPTION
A self-contained reference `SessionStore` implementation for MongoDB under `examples/session-stores/mongodb/`, alongside the existing S3/Redis/Postgres adapters. Imports `SessionStore`, `SessionKey`, and `SessionStoreEntry` types from the published `@anthropic-ai/claude-agent-sdk` package and passes the 13-contract conformance suite at `examples/session-stores/shared/conformance.ts`.

| Adapter   | Backend client | Unit tests       | Live tests                                |
| ---       | ---            | ---              | ---                                       |
| `mongodb/` | `mongodb`      | constructor only | env-gated `SESSION_STORE_MONGODB_URL`     |

### Storage model

One document per JSONL entry, ordering via the server-generated `_id` (`ObjectId`) — same property the Postgres adapter exploits with `BIGSERIAL`.

```ts
{ _id, projectKey, sessionId, subpath: string|null, entry, createdAt }
```

`ensureSchema()` is idempotent and creates two compound indexes covering `load()`/`delete()`/`listSubkeys()` and `listSessions()` respectively. The adapter follows the Postgres pattern of live-only conformance: there is no in-process Mongo mock that faithfully exercises the aggregation pipeline and `distinct`.

### Running

```bash
cd examples/session-stores/mongodb
npm install
npm test                                                              # constructor-only, no DB

docker run -d -p 27017:27017 mongo:latest
SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 npm run test:live # live conformance
SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 npm run demo      # query() + resume
```

### CI / packaging impact: none

Nothing under `examples/` is packaged, published, or built by repo CI; `examples/.gitignore` already excludes `node_modules` and lockfiles. No workflow files added. The umbrella `examples/session-stores/README.md` is updated to advertise the new adapter (table row, layout glob, MongoDB section, production checklist).

### Verified locally

- `bun run typecheck` clean.
- No-DB unit tests: `bun test test/MongoDBSessionStore.test.ts` — 2/2 pass; live suite skips cleanly when env unset.
- Live conformance against `docker run -d -p 27017:27017 mongo:latest`: **15/15 pass** (13 contract tests + `ensureSchema is idempotent` + `listSessions mtime is epoch ms`).
- End-to-end demo round-trip: first call replied `pineapple`, second call resumed from Mongo and replied `pineapple` again. `mongosh` confirmed 18 entries persisted under `claude_test.claude_session_entries`.

## Test plan

- [ ] `cd examples/session-stores/mongodb && bun install && bun run typecheck`
- [ ] `bun test test/MongoDBSessionStore.test.ts` — 2/2 pass with no infra
- [ ] `docker run -d -p 27017:27017 mongo:latest` then `SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 bun run test:live` — 15/15 pass
- [ ] With `ANTHROPIC_API_KEY` set, `SESSION_STORE_MONGODB_URL=mongodb://localhost:27017 bun run demo.ts` prints two `pineapple` results