### PR TITLE
fix: prevent partial Redis session updates on errors

### DIFF
--- a/examples/session-stores/README.md
+++ b/examples/session-stores/README.md
@@ -203,7 +203,7 @@ for await (const message of query({
 {prefix}:{projectKey}:__sessions              zset   — sessionId → mtime(ms)
 ```
 
-Each `append()` is an `RPUSH` plus an index update in a single `MULTI`;
+Each `append()` atomically checks key types, runs `RPUSH`, and updates the index;
 `load()` is `LRANGE 0 -1`.
 
 ### Live Redis end-to-end

--- a/examples/session-stores/redis/src/RedisSessionStore.ts
+++ b/examples/session-stores/redis/src/RedisSessionStore.ts
@@ -17,6 +17,32 @@ const SUBKEYS = '__subkeys'
 /** Reserved sessionId sentinel for the per-project session index. */
 const SESSIONS = '__sessions'
 
+const APPEND_SCRIPT = `
+local entry_type = redis.call('TYPE', KEYS[1]).ok
+local index_type = redis.call('TYPE', KEYS[2]).ok
+if entry_type ~= 'none' and entry_type ~= 'list' then
+  return redis.error_reply('WRONGTYPE transcript key must hold a list')
+end
+if index_type ~= 'none' and index_type ~= ARGV[1] then
+  return redis.error_reply('WRONGTYPE index key must hold a ' .. ARGV[1])
+end
+local first_entry = ARGV[1] == 'set' and 3 or 4
+local length = redis.call('RPUSH', KEYS[1], unpack(ARGV, first_entry))
+if ARGV[1] == 'set' then
+  redis.call('SADD', KEYS[2], ARGV[2])
+else
+  redis.call('ZADD', KEYS[2], ARGV[2], ARGV[3])
+end
+return length
+`
+
+function throwTransactionError(
+  results: [error: Error | null, result: unknown][] | null,
+): void {
+  const error = results?.find(([commandError]) => commandError)?.[0]
+  if (error) throw error
+}
+
 /**
  * Redis-backed SessionStore.
  *
@@ -62,17 +88,21 @@ export class RedisSessionStore implements SessionStore {
 
   async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
     if (entries.length === 0) return
-    const pipe = this.client.multi()
-    pipe.rpush(this.entryKey(key), ...entries.map(e => JSON.stringify(e)))
-    if (key.subpath) {
-      pipe.sadd(this.subkeysKey(key), key.subpath)
-    } else {
-      // Only main-transcript appends bump the session index — matches
-      // InMemorySessionStore.listSessions()'s "no subpath" filter and the S3
-      // adapter's main-parts-only mtime derivation.
-      pipe.zadd(this.sessionsKey(key.projectKey), Date.now(), key.sessionId)
-    }
-    await pipe.exec()
+    const indexKey = key.subpath
+      ? this.subkeysKey(key)
+      : this.sessionsKey(key.projectKey)
+    const indexArgs = key.subpath
+      ? ['set', key.subpath]
+      : ['zset', Date.now(), key.sessionId]
+
+    await this.client.eval(
+      APPEND_SCRIPT,
+      2,
+      this.entryKey(key),
+      indexKey,
+      ...indexArgs,
+      ...entries.map(e => JSON.stringify(e)),
+    )
   }
 
   async load(key: SessionKey): Promise<SessionStoreEntry[] | null> {
@@ -108,11 +138,13 @@ export class RedisSessionStore implements SessionStore {
   async delete(key: SessionKey): Promise<void> {
     if (key.subpath !== undefined) {
       // Targeted: remove just this subpath list and its index entry.
-      await this.client
-        .multi()
-        .del(this.entryKey(key))
-        .srem(this.subkeysKey(key), key.subpath)
-        .exec()
+      throwTransactionError(
+        await this.client
+          .multi()
+          .del(this.entryKey(key))
+          .srem(this.subkeysKey(key), key.subpath)
+          .exec(),
+      )
       return
     }
     // Cascade: main list + every subpath list + subkey set + session-index entry.
@@ -123,11 +155,13 @@ export class RedisSessionStore implements SessionStore {
       subkeysKey,
       ...subpaths.map(sp => this.entryKey({ ...key, subpath: sp })),
     ]
-    await this.client
-      .multi()
-      .del(...toDelete)
-      .zrem(this.sessionsKey(key.projectKey), key.sessionId)
-      .exec()
+    throwTransactionError(
+      await this.client
+        .multi()
+        .del(...toDelete)
+        .zrem(this.sessionsKey(key.projectKey), key.sessionId)
+        .exec(),
+    )
   }
 
   async listSubkeys(key: {

--- a/examples/session-stores/redis/src/RedisSessionStore.ts
+++ b/examples/session-stores/redis/src/RedisSessionStore.ts
@@ -18,6 +18,7 @@ const SUBKEYS = '__subkeys'
 const SESSIONS = '__sessions'
 
 const APPEND_SCRIPT = `
+-- append
 local entry_type = redis.call('TYPE', KEYS[1]).ok
 local index_type = redis.call('TYPE', KEYS[2]).ok
 if entry_type ~= 'none' and entry_type ~= 'list' then
@@ -27,7 +28,10 @@ if index_type ~= 'none' and index_type ~= ARGV[1] then
   return redis.error_reply('WRONGTYPE index key must hold a ' .. ARGV[1])
 end
 local first_entry = ARGV[1] == 'set' and 3 or 4
-local length = redis.call('RPUSH', KEYS[1], unpack(ARGV, first_entry))
+local length = 0
+for i = first_entry, #ARGV, 1000 do
+  length = redis.call('RPUSH', KEYS[1], unpack(ARGV, i, math.min(i + 999, #ARGV)))
+end
 if ARGV[1] == 'set' then
   redis.call('SADD', KEYS[2], ARGV[2])
 else
@@ -36,12 +40,39 @@ end
 return length
 `
 
-function throwTransactionError(
-  results: [error: Error | null, result: unknown][] | null,
-): void {
-  const error = results?.find(([commandError]) => commandError)?.[0]
-  if (error) throw error
-}
+const DELETE_SUBPATH_SCRIPT = `
+-- delete-subpath
+local index_type = redis.call('TYPE', KEYS[2]).ok
+if index_type ~= 'none' and index_type ~= 'set' then
+  return redis.error_reply('WRONGTYPE subpath index key must hold a set')
+end
+redis.call('DEL', KEYS[1])
+redis.call('SREM', KEYS[2], ARGV[1])
+return 1
+`
+
+const DELETE_SESSION_SCRIPT = `
+-- delete-session
+local subkeys_type = redis.call('TYPE', KEYS[2]).ok
+local sessions_type = redis.call('TYPE', KEYS[3]).ok
+if subkeys_type ~= 'none' and subkeys_type ~= 'set' then
+  return redis.error_reply('WRONGTYPE subpath index key must hold a set')
+end
+if sessions_type ~= 'none' and sessions_type ~= 'zset' then
+  return redis.error_reply('WRONGTYPE session index key must hold a zset')
+end
+local subpaths = redis.call('SMEMBERS', KEYS[2])
+redis.call('DEL', KEYS[1], KEYS[2])
+for i = 1, #subpaths, 1000 do
+  local keys = {}
+  for j = i, math.min(i + 999, #subpaths) do
+    keys[#keys + 1] = KEYS[1] .. ':' .. subpaths[j]
+  end
+  redis.call('DEL', unpack(keys))
+end
+redis.call('ZREM', KEYS[3], ARGV[1])
+return 1
+`
 
 /**
  * Redis-backed SessionStore.
@@ -137,30 +168,22 @@ export class RedisSessionStore implements SessionStore {
 
   async delete(key: SessionKey): Promise<void> {
     if (key.subpath !== undefined) {
-      // Targeted: remove just this subpath list and its index entry.
-      throwTransactionError(
-        await this.client
-          .multi()
-          .del(this.entryKey(key))
-          .srem(this.subkeysKey(key), key.subpath)
-          .exec(),
+      await this.client.eval(
+        DELETE_SUBPATH_SCRIPT,
+        2,
+        this.entryKey(key),
+        this.subkeysKey(key),
+        key.subpath,
       )
       return
     }
-    // Cascade: main list + every subpath list + subkey set + session-index entry.
-    const subkeysKey = this.subkeysKey(key)
-    const subpaths = await this.client.smembers(subkeysKey)
-    const toDelete = [
+    await this.client.eval(
+      DELETE_SESSION_SCRIPT,
+      3,
       this.entryKey(key),
-      subkeysKey,
-      ...subpaths.map(sp => this.entryKey({ ...key, subpath: sp })),
-    ]
-    throwTransactionError(
-      await this.client
-        .multi()
-        .del(...toDelete)
-        .zrem(this.sessionsKey(key.projectKey), key.sessionId)
-        .exec(),
+      this.subkeysKey(key),
+      this.sessionsKey(key.projectKey),
+      key.sessionId,
     )
   }
 

--- a/examples/session-stores/redis/src/RedisSessionStore.ts
+++ b/examples/session-stores/redis/src/RedisSessionStore.ts
@@ -28,6 +28,18 @@ if index_type ~= 'none' and index_type ~= ARGV[1] then
   return redis.error_reply('WRONGTYPE index key must hold a ' .. ARGV[1])
 end
 local first_entry = ARGV[1] == 'set' and 3 or 4
+if not redis.acl_check_cmd('RPUSH', KEYS[1], ARGV[first_entry]) then
+  return redis.error_reply('NOPERM append requires RPUSH access')
+end
+if ARGV[1] == 'set' then
+  if not redis.acl_check_cmd('SADD', KEYS[2], ARGV[2]) then
+    return redis.error_reply('NOPERM append requires SADD access')
+  end
+else
+  if not redis.acl_check_cmd('ZADD', KEYS[2], ARGV[2], ARGV[3]) then
+    return redis.error_reply('NOPERM append requires ZADD access')
+  end
+end
 local length = 0
 for i = first_entry, #ARGV, 1000 do
   length = redis.call('RPUSH', KEYS[1], unpack(ARGV, i, math.min(i + 999, #ARGV)))
@@ -46,6 +58,12 @@ local index_type = redis.call('TYPE', KEYS[2]).ok
 if index_type ~= 'none' and index_type ~= 'set' then
   return redis.error_reply('WRONGTYPE subpath index key must hold a set')
 end
+if not redis.acl_check_cmd('DEL', KEYS[1]) then
+  return redis.error_reply('NOPERM delete requires DEL access')
+end
+if not redis.acl_check_cmd('SREM', KEYS[2], ARGV[1]) then
+  return redis.error_reply('NOPERM delete requires SREM access')
+end
 redis.call('DEL', KEYS[1])
 redis.call('SREM', KEYS[2], ARGV[1])
 return 1
@@ -61,14 +79,24 @@ end
 if sessions_type ~= 'none' and sessions_type ~= 'zset' then
   return redis.error_reply('WRONGTYPE session index key must hold a zset')
 end
+if not redis.acl_check_cmd('SMEMBERS', KEYS[2]) then
+  return redis.error_reply('NOPERM delete requires SMEMBERS access')
+end
 local subpaths = redis.call('SMEMBERS', KEYS[2])
-redis.call('DEL', KEYS[1], KEYS[2])
-for i = 1, #subpaths, 1000 do
-  local keys = {}
-  for j = i, math.min(i + 999, #subpaths) do
-    keys[#keys + 1] = KEYS[1] .. ':' .. subpaths[j]
+local delete_keys = {KEYS[1], KEYS[2]}
+for i = 1, #subpaths do
+  delete_keys[#delete_keys + 1] = KEYS[1] .. ':' .. subpaths[i]
+end
+for i = 1, #delete_keys, 1000 do
+  if not redis.acl_check_cmd('DEL', unpack(delete_keys, i, math.min(i + 999, #delete_keys))) then
+    return redis.error_reply('NOPERM delete requires DEL access')
   end
-  redis.call('DEL', unpack(keys))
+end
+if not redis.acl_check_cmd('ZREM', KEYS[3], ARGV[1]) then
+  return redis.error_reply('NOPERM delete requires ZREM access')
+end
+for i = 1, #delete_keys, 1000 do
+  redis.call('DEL', unpack(delete_keys, i, math.min(i + 999, #delete_keys)))
 end
 redis.call('ZREM', KEYS[3], ARGV[1])
 return 1

--- a/examples/session-stores/redis/test/RedisSessionStore.test.ts
+++ b/examples/session-stores/redis/test/RedisSessionStore.test.ts
@@ -5,7 +5,7 @@ import { runSessionStoreConformance } from '../../shared/conformance.ts'
 
 /**
  * Minimal in-process ioredis mock backing the subset of commands the adapter
- * uses: rpush/lrange, sadd/srem/smembers, zadd/zrange/zrem, del, multi.
+ * uses: rpush/lrange, sadd/srem/smembers, zadd/zrange/zrem, del, eval, multi.
  * `multi()` executes eagerly (no isolation needed for single-threaded tests).
  */
 function makeMockRedis(): Redis {
@@ -78,6 +78,26 @@ function makeMockRedis(): Redis {
         if (zsets.delete(k)) n++
       }
       return n
+    },
+    async eval(
+      _script: string,
+      _numberOfKeys: number,
+      entryKey: string,
+      indexKey: string,
+      indexType: 'set' | 'zset',
+      ...args: Array<string | number>
+    ) {
+      const indexArgCount = indexType === 'set' ? 1 : 2
+      const length = await api.rpush(
+        entryKey,
+        ...args.slice(indexArgCount).map(String),
+      )
+      if (indexType === 'set') {
+        await api.sadd(indexKey, String(args[0]))
+      } else {
+        await api.zadd(indexKey, Number(args[0]), String(args[1]))
+      }
+      return length
     },
     async keys(pattern: string) {
       const all = new Set([...lists.keys(), ...sets.keys(), ...zsets.keys()])

--- a/examples/session-stores/redis/test/RedisSessionStore.test.ts
+++ b/examples/session-stores/redis/test/RedisSessionStore.test.ts
@@ -5,8 +5,7 @@ import { runSessionStoreConformance } from '../../shared/conformance.ts'
 
 /**
  * Minimal in-process ioredis mock backing the subset of commands the adapter
- * uses: rpush/lrange, sadd/srem/smembers, zadd/zrange/zrem, del, eval, multi.
- * `multi()` executes eagerly (no isolation needed for single-threaded tests).
+ * uses: rpush/lrange, sadd/srem/smembers, zadd/zrange/zrem, del, eval.
  */
 function makeMockRedis(): Redis {
   const lists = new Map<string, string[]>()
@@ -80,24 +79,45 @@ function makeMockRedis(): Redis {
       return n
     },
     async eval(
-      _script: string,
-      _numberOfKeys: number,
-      entryKey: string,
-      indexKey: string,
-      indexType: 'set' | 'zset',
-      ...args: Array<string | number>
+      script: string,
+      numberOfKeys: number,
+      ...rawArgs: Array<string | number>
     ) {
-      const indexArgCount = indexType === 'set' ? 1 : 2
-      const length = await api.rpush(
-        entryKey,
-        ...args.slice(indexArgCount).map(String),
-      )
-      if (indexType === 'set') {
-        await api.sadd(indexKey, String(args[0]))
-      } else {
-        await api.zadd(indexKey, Number(args[0]), String(args[1]))
+      const keys = rawArgs.slice(0, numberOfKeys).map(String)
+      const args = rawArgs.slice(numberOfKeys)
+      if (script.includes('-- append')) {
+        const [entryKey, indexKey] = keys as [string, string]
+        const indexType = String(args[0])
+        const indexArgCount = indexType === 'set' ? 2 : 3
+        const length = await api.rpush(
+          entryKey,
+          ...args.slice(indexArgCount).map(String),
+        )
+        if (indexType === 'set') {
+          await api.sadd(indexKey, String(args[1]))
+        } else {
+          await api.zadd(indexKey, Number(args[1]), String(args[2]))
+        }
+        return length
       }
-      return length
+      if (script.includes('-- delete-subpath')) {
+        await api.del(keys[0]!)
+        await api.srem(keys[1]!, String(args[0]))
+        return 1
+      }
+      const [entryKey, subkeysKey, sessionsKey] = keys as [
+        string,
+        string,
+        string,
+      ]
+      const subpaths = await api.smembers(subkeysKey)
+      await api.del(
+        entryKey,
+        subkeysKey,
+        ...subpaths.map(subpath => `${entryKey}:${subpath}`),
+      )
+      await api.zrem(sessionsKey, String(args[0]))
+      return 1
     },
     async keys(pattern: string) {
       const all = new Set([...lists.keys(), ...sets.keys(), ...zsets.keys()])
@@ -106,32 +126,6 @@ function makeMockRedis(): Redis {
         '^' + pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$',
       )
       return [...all].filter(k => re.test(k))
-    },
-    multi() {
-      const queue: Array<() => Promise<unknown>> = []
-      const chain: Record<string, unknown> = {
-        async exec() {
-          const out: Array<[null, unknown]> = []
-          for (const fn of queue) out.push([null, await fn()])
-          return out
-        },
-      }
-      for (const cmd of [
-        'rpush',
-        'sadd',
-        'srem',
-        'zadd',
-        'zrem',
-        'del',
-      ] as const) {
-        chain[cmd] = (...args: unknown[]) => {
-          queue.push(() =>
-            (api[cmd] as (...a: unknown[]) => Promise<unknown>)(...args),
-          )
-          return chain
-        }
-      }
-      return chain
     },
   }
   return api as unknown as Redis

--- a/examples/session-stores/redis/test/conformance.live.test.ts
+++ b/examples/session-stores/redis/test/conformance.live.test.ts
@@ -5,7 +5,7 @@
  *   docker run -d -p 6379:6379 redis:7-alpine
  *   SESSION_STORE_REDIS_URL=redis://localhost:6379/0 bun test test/conformance.live.test.ts
  */
-import { afterAll, describe } from 'bun:test'
+import { afterAll, describe, expect, test } from 'bun:test'
 import Redis from 'ioredis'
 import { RedisSessionStore } from '../src/RedisSessionStore.ts'
 import { runSessionStoreConformance } from '../../shared/conformance.ts'
@@ -20,6 +20,37 @@ describe.skipIf(!url)('RedisSessionStore (live conformance)', () => {
   runSessionStoreConformance(
     () => new RedisSessionStore({ client, prefix: `${root}:${n++}` }),
   )
+
+  test('append rejects Redis transaction command errors', async () => {
+    const prefix = `${root}:errors`
+    const store = new RedisSessionStore({ client, prefix })
+    await client.set(`${prefix}:p:s`, 'wrong-type')
+
+    await expect(
+      store.append(
+        { projectKey: 'p', sessionId: 's' },
+        [{ type: 'assistant' }],
+      ),
+    ).rejects.toThrow('WRONGTYPE')
+    expect(await client.zscore(`${prefix}:p:__sessions`, 's')).toBeNull()
+  })
+
+  test('three SDK retries of an index failure do not duplicate entries', async () => {
+    const prefix = `${root}:retry`
+    const store = new RedisSessionStore({ client, prefix })
+    await client.set(`${prefix}:p:__sessions`, 'wrong-type')
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      await expect(
+        store.append(
+          { projectKey: 'p', sessionId: 's' },
+          [{ type: 'assistant' }],
+        ),
+      ).rejects.toThrow('WRONGTYPE')
+    }
+
+    expect(await client.lrange(`${prefix}:p:s`, 0, -1)).toEqual([])
+  })
 
   afterAll(async () => {
     const keys = await client.keys(`${root}:*`)

--- a/examples/session-stores/redis/test/conformance.live.test.ts
+++ b/examples/session-stores/redis/test/conformance.live.test.ts
@@ -40,7 +40,7 @@ describe.skipIf(!url)('RedisSessionStore (live conformance)', () => {
       ...commands,
     )
     return {
-      redis: new Redis(url!, {
+      redis: client.duplicate({
         enableReadyCheck: false,
         lazyConnect: false,
         username,
@@ -233,7 +233,7 @@ describe.skipIf(!url)('RedisSessionStore (live conformance)', () => {
       selector(deleteKeys.slice(1000, 1002)),
       selector(deleteKeys.slice(1002)),
     )
-    const redis = new Redis(url!, {
+    const redis: Redis = client.duplicate({
       enableReadyCheck: false,
       lazyConnect: false,
       username,

--- a/examples/session-stores/redis/test/conformance.live.test.ts
+++ b/examples/session-stores/redis/test/conformance.live.test.ts
@@ -21,6 +21,35 @@ describe.skipIf(!url)('RedisSessionStore (live conformance)', () => {
     () => new RedisSessionStore({ client, prefix: `${root}:${n++}` }),
   )
 
+  async function createRestrictedClient(
+    prefix: string,
+    commands: string[],
+  ): Promise<{ redis: Redis; username: string }> {
+    const username = `${root.replace(/[^a-zA-Z0-9]/g, '')}${n++}`
+    const password = 'review-password'
+    await client.call(
+      'ACL',
+      'SETUSER',
+      username,
+      'reset',
+      'on',
+      `>${password}`,
+      `~${prefix}:*`,
+      '+eval',
+      '+type',
+      ...commands,
+    )
+    return {
+      redis: new Redis(url!, {
+        enableReadyCheck: false,
+        lazyConnect: false,
+        username,
+        password,
+      }),
+      username,
+    }
+  }
+
   test('append rejects Redis transaction command errors', async () => {
     const prefix = `${root}:errors`
     const store = new RedisSessionStore({ client, prefix })
@@ -96,6 +125,131 @@ describe.skipIf(!url)('RedisSessionStore (live conformance)', () => {
 
     await expect(store.delete(key)).rejects.toThrow('WRONGTYPE')
     expect(await store.load(key)).toEqual([entry])
+  })
+
+  test('append does not mutate when the session index cannot be updated', async () => {
+    const prefix = `${root}:append-acl`
+    const { redis, username } = await createRestrictedClient(prefix, [
+      '+rpush',
+    ])
+    const store = new RedisSessionStore({ client: redis, prefix })
+    try {
+      await expect(
+        store.append(
+          { projectKey: 'p', sessionId: 's' },
+          [{ type: 'assistant' }],
+        ),
+      ).rejects.toThrow()
+      expect(await client.lrange(`${prefix}:p:s`, 0, -1)).toEqual([])
+    } finally {
+      await redis.quit()
+      await client.call('ACL', 'DELUSER', username)
+    }
+  })
+
+  test('main delete does not mutate when the session index cannot be updated', async () => {
+    const prefix = `${root}:delete-main-acl`
+    const key = { projectKey: 'p', sessionId: 's' }
+    const entry = { type: 'assistant' }
+    await new RedisSessionStore({ client, prefix }).append(key, [entry])
+    const { redis, username } = await createRestrictedClient(prefix, [
+      '+smembers',
+      '+del',
+    ])
+    try {
+      await expect(
+        new RedisSessionStore({ client: redis, prefix }).delete(key),
+      ).rejects.toThrow()
+      expect(
+        await new RedisSessionStore({ client, prefix }).load(key),
+      ).toEqual([entry])
+    } finally {
+      await redis.quit()
+      await client.call('ACL', 'DELUSER', username)
+    }
+  })
+
+  test('subpath delete does not mutate when its index cannot be updated', async () => {
+    const prefix = `${root}:delete-subpath-acl`
+    const key = {
+      projectKey: 'p',
+      sessionId: 's',
+      subpath: 'subagents/a',
+    }
+    const entry = { type: 'assistant' }
+    await new RedisSessionStore({ client, prefix }).append(key, [entry])
+    const { redis, username } = await createRestrictedClient(prefix, ['+del'])
+    try {
+      await expect(
+        new RedisSessionStore({ client: redis, prefix }).delete(key),
+      ).rejects.toThrow()
+      expect(
+        await new RedisSessionStore({ client, prefix }).load(key),
+      ).toEqual([entry])
+    } finally {
+      await redis.quit()
+      await client.call('ACL', 'DELUSER', username)
+    }
+  })
+
+  test('main delete preflights each exact multi-key batch', async () => {
+    const prefix = `${root}:delete-batch-acl`
+    const key = { projectKey: 'p', sessionId: 's' }
+    const entry = JSON.stringify({ type: 'assistant' })
+    const entryKey = `${prefix}:p:s`
+    const subkeysKey = `${entryKey}:__subkeys`
+    const sessionsKey = `${prefix}:p:__sessions`
+    const subpaths = Array.from(
+      { length: 1002 },
+      (_, index) => `subagents/${index}`,
+    )
+    const setup = client.pipeline().rpush(entryKey, entry)
+    for (const subpath of subpaths) {
+      setup.rpush(`${entryKey}:${subpath}`, entry)
+      setup.sadd(subkeysKey, subpath)
+    }
+    setup.zadd(sessionsKey, Date.now(), key.sessionId)
+    await setup.exec()
+
+    const orderedSubpaths = await client.smembers(subkeysKey)
+    const deleteKeys = [
+      entryKey,
+      subkeysKey,
+      ...orderedSubpaths.map(subpath => `${entryKey}:${subpath}`),
+    ]
+    const username = `${root.replace(/[^a-zA-Z0-9]/g, '')}${n++}`
+    const password = 'review-password'
+    const permissions = '+eval +type +smembers +del +zrem'
+    const selector = (keys: string[]) =>
+      `(${permissions} ${keys.map(redisKey => `~${redisKey}`).join(' ')})`
+    await client.call(
+      'ACL',
+      'SETUSER',
+      username,
+      'reset',
+      'on',
+      `>${password}`,
+      selector([...deleteKeys.slice(0, 1000), sessionsKey]),
+      selector(deleteKeys.slice(1000, 1002)),
+      selector(deleteKeys.slice(1002)),
+    )
+    const redis = new Redis(url!, {
+      enableReadyCheck: false,
+      lazyConnect: false,
+      username,
+      password,
+    })
+    try {
+      await expect(
+        new RedisSessionStore({ client: redis, prefix }).delete(key),
+      ).rejects.toThrow()
+      expect(await client.llen(entryKey)).toBe(1)
+      expect(await client.scard(subkeysKey)).toBe(subpaths.length)
+      expect(await client.zscore(sessionsKey, key.sessionId)).not.toBeNull()
+    } finally {
+      await redis.quit()
+      await client.call('ACL', 'DELUSER', username)
+    }
   })
 
   afterAll(async () => {

--- a/examples/session-stores/redis/test/conformance.live.test.ts
+++ b/examples/session-stores/redis/test/conformance.live.test.ts
@@ -52,6 +52,52 @@ describe.skipIf(!url)('RedisSessionStore (live conformance)', () => {
     expect(await client.lrange(`${prefix}:p:s`, 0, -1)).toEqual([])
   })
 
+  test('append supports batches larger than the Lua unpack limit', async () => {
+    const prefix = `${root}:large`
+    const store = new RedisSessionStore({ client, prefix })
+    const entries = Array.from({ length: 10_000 }, (_, index) => ({
+      type: 'assistant',
+      index,
+    }))
+
+    await store.append({ projectKey: 'p', sessionId: 's' }, entries)
+
+    const loaded = await store.load({ projectKey: 'p', sessionId: 's' })
+    expect(loaded).toHaveLength(entries.length)
+    expect(loaded?.[0]).toEqual(entries[0])
+    expect(loaded?.at(-1)).toEqual(entries.at(-1))
+  })
+
+  test('main delete is atomic when the session index has the wrong type', async () => {
+    const prefix = `${root}:delete-main`
+    const store = new RedisSessionStore({ client, prefix })
+    const key = { projectKey: 'p', sessionId: 's' }
+    const entry = { type: 'assistant' }
+    await store.append(key, [entry])
+    await client.del(`${prefix}:p:__sessions`)
+    await client.set(`${prefix}:p:__sessions`, 'wrong-type')
+
+    await expect(store.delete(key)).rejects.toThrow('WRONGTYPE')
+    expect(await store.load(key)).toEqual([entry])
+  })
+
+  test('subpath delete is atomic when the subpath index has the wrong type', async () => {
+    const prefix = `${root}:delete-subpath`
+    const store = new RedisSessionStore({ client, prefix })
+    const key = {
+      projectKey: 'p',
+      sessionId: 's',
+      subpath: 'subagents/a',
+    }
+    const entry = { type: 'assistant' }
+    await store.append(key, [entry])
+    await client.del(`${prefix}:p:s:__subkeys`)
+    await client.set(`${prefix}:p:s:__subkeys`, 'wrong-type')
+
+    await expect(store.delete(key)).rejects.toThrow('WRONGTYPE')
+    expect(await store.load(key)).toEqual([entry])
+  })
+
   afterAll(async () => {
     const keys = await client.keys(`${root}:*`)
     if (keys.length) await client.del(...keys)


### PR DESCRIPTION
An index error could leave a Redis append or delete partly applied, and retries could duplicate entries. The reference adapter now rejects wrong key types and denied commands before mutation. Large appends use bounded chunks. ACL tests also preserve restricted credentials when the URL contains credentials.

Closes https://github.com/anthropics/claude-agent-sdk-typescript/issues/440

## Testing

These tests use isolated Redis 7.4.11, not a model session. The same public live tests run against archived source, with no runtime edits. The main baseline runs type/size cases; both Lua revisions run the full suite. Run this from the PR root with example dependencies installed.

<details><summary>Commands and raw output</summary>

```bash
P=examples/session-stores/redis
T=test/conformance.live.test.ts
deps="$PWD/$P/node_modules"
id=$(docker run -d --pull never -p 127.0.0.1::6379 --read-only --cap-drop ALL --security-opt no-new-privileges --user 65534:65534 --entrypoint redis-server redis:7-alpine --requirepass local-proof --save '' --appendonly no)
export SESSION_STORE_REDIS_URL="redis://:local-proof@$(docker port "$id" 6379/tcp)/0"
for ref in 80eebc4881da2f11140deb6114f4bceff8da704a d0d7adafbe20d0085940a22918fa158d31825474 HEAD; do
  D=$(mktemp -d)
  git archive "$ref" examples/session-stores | tar -x -C "$D"
  git archive HEAD "$P/$T" | tar -x -C "$D"
  ln -s "$deps" "$D/$P/node_modules"
  filter='.'
  if [ "$ref" = 80eebc4881da2f11140deb6114f4bceff8da704a ]; then
    filter='transaction command errors|three SDK retries|wrong type|Lua unpack'
  fi
  if (cd "$D/$P" && bun test "$T" -t "$filter"); then
    echo "$ref passed"
  else
    echo "$ref failed"
  fi
done
docker stop "$id"
docker rm "$id"
```

```text
Main baseline, wrong-type append/delete:
Expected promise that rejects
Received promise that resolved: Promise { <resolved> }
 1 pass
 17 filtered out
 4 fail

Before ACL preflight, main delete:
Expected: 1
Received: 0
 18 pass
 4 fail

PR head:
 22 pass
 0 fail
```

</details>
