### PR TITLE
fix: keep S3 session parts ordered across writers

### DIFF
--- a/examples/session-stores/README.md
+++ b/examples/session-stores/README.md
@@ -125,11 +125,15 @@ through the relevant items below.
 Stores transcripts as JSONL part files:
 
 ```
-s3://{bucket}/{prefix}{projectKey}/{sessionId}/part-{epochMs13}-{rand6}.jsonl
+s3://{bucket}/{prefix}{projectKey}/{sessionId}/part-{epochMs13}-{seq6}-{rand6}.jsonl
 ```
 
 Each `append()` writes a new part; `load()` lists, sorts, and concatenates
-them.
+them. Sorting the names lexically is what puts the entries back in order: the
+millisecond orders parts across writers, the sequence orders one instance's
+appends inside a millisecond, and the random suffix breaks the remaining ties.
+Parts written before the sequence field was added are still read and still
+carry their timestamp.
 
 ```typescript
 import { S3Client } from '@aws-sdk/client-s3'

--- a/examples/session-stores/s3/src/S3SessionStore.ts
+++ b/examples/session-stores/s3/src/S3SessionStore.ts
@@ -27,14 +27,17 @@ export type S3SessionStoreOptions = {
 }
 
 /**
- * S3-backed SessionStore. append() = new part file `{prefix}{projectKey}/{sessionId}/part-{epochMs13}-{rand6}.jsonl`;
- * load() = list+sort+concat. Monotonic ms orders same-instance same-ms appends; rand suffix disambiguates instances.
+ * S3-backed SessionStore. append() = new part file `{prefix}{projectKey}/{sessionId}/part-{epochMs13}-{seq6}-{rand6}.jsonl`;
+ * load() = list+sort+concat. The epoch ms orders appends across writers, the
+ * per-millisecond sequence orders same-instance appends inside one ms, and the
+ * rand suffix disambiguates instances that land on the same ms and sequence.
  */
 export class S3SessionStore implements SessionStore {
   private readonly bucket: string
   private readonly prefix: string
   private readonly client: S3Client
   private lastMs = 0
+  private seq = 0
 
   constructor(options: S3SessionStoreOptions) {
     this.bucket = options.bucket
@@ -58,15 +61,26 @@ export class S3SessionStore implements SessionStore {
   }
 
   /**
-   * Fixed-width epoch ms → lexical sort = chronological. lastMs+1 makes
-   * same-instance same-ms appends deterministic; rand disambiguates instances.
+   * Fixed-width epoch ms → lexical sort = chronological. The sequence counter
+   * separates same-instance appends inside one millisecond without moving the
+   * timestamp: borrowing from a later millisecond would sort this instance's
+   * burst after a part another writer stamps with the millisecond it borrowed,
+   * and two writers sharing a bucket is the reason to use this adapter at all.
+   * A clock that steps backwards keeps the last millisecond and advances the
+   * sequence, so an instance's own parts stay in the order it wrote them.
    */
   private nextPartName(): string {
     const now = Date.now()
-    const ms = Math.max(now, this.lastMs + 1)
-    this.lastMs = ms
+    if (now > this.lastMs) {
+      this.lastMs = now
+      this.seq = 0
+    } else {
+      this.seq += 1
+    }
     const rand = Math.random().toString(16).slice(2, 8).padStart(6, '0')
-    return `part-${ms.toString().padStart(13, '0')}-${rand}.jsonl`
+    return `part-${this.lastMs.toString().padStart(13, '0')}-${this.seq
+      .toString()
+      .padStart(6, '0')}-${rand}.jsonl`
   }
 
   async append(key: SessionKey, entries: SessionStoreEntry[]): Promise<void> {
@@ -194,7 +208,10 @@ export class S3SessionStore implements SessionStore {
             continue
           }
           const sessionId = rest.slice(0, slash)
-          const m = obj.Key.match(/\/part-(\d{13})-[0-9a-f]{6}\.jsonl$/)
+          // Parts written before the sequence field carry only the rand suffix.
+          const m = obj.Key.match(
+            /\/part-(\d{13})-(?:\d{6}-)?[0-9a-f]{6}\.jsonl$/,
+          )
           const mtime = m ? Number(m[1]) : (obj.LastModified?.getTime() ?? 0)
           const prev = sessions.get(sessionId) ?? 0
           if (mtime > prev) {

--- a/examples/session-stores/s3/test/S3SessionStore.test.ts
+++ b/examples/session-stores/s3/test/S3SessionStore.test.ts
@@ -70,7 +70,7 @@ describe('S3SessionStore (adapter-specific)', () => {
     const store = new S3SessionStore({ bucket: 'b', prefix: 't', client })
     await store.append(KEY, [{ type: 'a' }])
     const [k] = [...objects.keys()]
-    expect(k).toMatch(/^t\/p\/s\/part-\d{13}-[0-9a-f]{6}\.jsonl$/)
+    expect(k).toMatch(/^t\/p\/s\/part-\d{13}-\d{6}-[0-9a-f]{6}\.jsonl$/)
   })
 
   test('same-ms appends are lexically ordered (monotonic counter)', async () => {
@@ -89,6 +89,68 @@ describe('S3SessionStore (adapter-specific)', () => {
     expect(ks).toEqual([...objects.keys()])
     const loaded = await store.load(KEY)
     expect(loaded?.map(e => e.type)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('a burst does not sort ahead of another writer on the same bucket', async () => {
+    // Two instances mirroring one session is the reason to use a shared
+    // backend. Advancing the timestamp to separate a burst hands the borrowed
+    // milliseconds to whoever writes next, and their part lands inside the
+    // burst.
+    const { client, objects } = makeMockClient()
+    const a = new S3SessionStore({ bucket: 'b', client })
+    const b = new S3SessionStore({ bucket: 'b', client })
+    const original = Date.now
+    let clock = 1700000000000
+    Date.now = () => clock
+    try {
+      for (const type of ['a1', 'a2', 'a3', 'a4', 'a5']) {
+        await a.append(KEY, [{ type }])
+      }
+      clock += 1
+      await b.append(KEY, [{ type: 'b1' }])
+      clock += 1
+      await a.append(KEY, [{ type: 'a6' }])
+    } finally {
+      Date.now = original
+    }
+    expect([...objects.keys()].sort()).toEqual([...objects.keys()])
+    const loaded = await a.load(KEY)
+    expect(loaded?.map(e => e.type)).toEqual([
+      'a1',
+      'a2',
+      'a3',
+      'a4',
+      'a5',
+      'b1',
+      'a6',
+    ])
+  })
+
+  test('a clock that steps backwards keeps an instance in write order', async () => {
+    const { client } = makeMockClient()
+    const store = new S3SessionStore({ bucket: 'b', client })
+    const original = Date.now
+    let clock = 1700000000000
+    Date.now = () => clock
+    try {
+      await store.append(KEY, [{ type: 'a' }])
+      clock -= 5
+      await store.append(KEY, [{ type: 'b' }])
+      await store.append(KEY, [{ type: 'c' }])
+    } finally {
+      Date.now = original
+    }
+    const loaded = await store.load(KEY)
+    expect(loaded?.map(e => e.type)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('listSessions reads the mtime of a part written before the sequence field', async () => {
+    const { client, objects } = makeMockClient()
+    objects.set('p/s/part-1700000000000-abcdef.jsonl', '{"type":"a"}\n')
+    const store = new S3SessionStore({ bucket: 'b', client })
+    expect(await store.listSessions('p')).toEqual([
+      { sessionId: 's', mtime: 1700000000000 },
+    ])
   })
 
   test('append([]) issues no PutObject', async () => {


### PR DESCRIPTION
`nextPartName()` separated same-millisecond appends by advancing the timestamp past the clock (`Math.max(now, this.lastMs + 1)`). Those borrowed milliseconds then belong to whoever writes next, so a second instance sharing the bucket stamps a part with a millisecond the first instance had already taken, and its part sorts inside the earlier burst.

```ts
const a = new S3SessionStore({ bucket, client })   // two processes mirroring
const b = new S3SessionStore({ bucket, client })   // the same session

// t = T
for (const type of ['a1','a2','a3','a4','a5']) await a.append(KEY, [{ type }])
// t = T+1
await b.append(KEY, [{ type: 'b1' }])
// t = T+2
await a.append(KEY, [{ type: 'a6' }])

await a.load(KEY)
// written: a1 a2 a3 a4 a5 b1 a6
// loaded:  a1 b1 a2 a3 a4 a5 a6
```

`a`'s burst is named `T … T+4`, so `b`'s part — stamped with the real `T+1` — lands in position two. The rand suffix only breaks ties inside one millisecond; it cannot undo a name that claims a millisecond that has not arrived.

This matters because the transcript is what resume replays. Across 300 appends from two instances, 1747 of 44460 pairs written at different wall-clock times came back inverted:

| instances | inversions before | after |
| --- | --- | --- |
| 1 | 0 / 44460 | 0 / 44460 |
| 2 | 1747 / 44460 | 0 / 44460 |
| 3 | 383 / 44460 | 0 / 44460 |

A single instance was always correct, which is why the conformance suite did not catch it — every case builds one store, and one writer is the case that works.

The fix keeps the timestamp honest and puts the burst counter in its own field:

```
part-{epochMs13}-{rand6}.jsonl  →  part-{epochMs13}-{seq6}-{rand6}.jsonl
```

The millisecond orders parts across writers, the sequence orders one instance's appends inside a millisecond, and the rand suffix breaks what is left. A clock that steps backwards keeps the last millisecond and advances the sequence, so an instance's own parts stay in write order — the property `Math.max(now, lastMs + 1)` was also providing.

`listSessions()` matches both name shapes, so a bucket written by an earlier version keeps its timestamps and still loads in order. Parts of the two shapes are only unordered relative to each other inside a single shared millisecond, where two writers have no ordering to preserve anyway.

Three tests added: a burst against a second writer on one bucket, a backwards clock, and `listSessions()` reading a part written before the sequence field. The first fails on `main`. The existing same-millisecond ordering test and the 13 conformance checks pass unchanged; 25 tests in `s3/`, and the Redis and Postgres adapters are untouched.
